### PR TITLE
feat: Ghost Tracking — session no-show tracking (v5.0)

### DIFF
--- a/rollCall/db.py
+++ b/rollCall/db.py
@@ -458,6 +458,20 @@ def _migrate_schema(conn):
         except Exception:
             # Column already exists — safe to ignore
             conn.rollback()
+
+    # Stamp all pre-existing rollcalls as already processed so the ghost
+    # tracking prompt never fires for roll calls that started before this
+    # deployment.  New rollcalls get absent_marked = FALSE (the DB default)
+    # and are therefore fully eligible for ghost tracking.
+    try:
+        if db_type == 'postgresql':
+            cursor.execute("UPDATE rollcalls SET absent_marked = TRUE WHERE absent_marked = FALSE")
+        else:
+            cursor.execute("UPDATE rollcalls SET absent_marked = 1 WHERE absent_marked = 0")
+        conn.commit()
+    except Exception:
+        conn.rollback()
+
     if db_type == 'postgresql':
         cursor.close()
 

--- a/rollCall/telegram_helper.py
+++ b/rollCall/telegram_helper.py
@@ -1831,7 +1831,7 @@ async def end_roll_call(message):
         manager.remove_rollcall(cid, rc_number)
         logging.info(f"[CHAT {cid}] Rollcall ended: '{rc.title}' by {message.from_user.first_name} (@{message.from_user.username})")
         # Ghost tracking prompt
-        if ghost_tracking_on and had_in_users and rc_db_id:
+        if ghost_tracking_on and had_in_users and rc_db_id and not rc.absent_marked:
             markup = InlineKeyboardMarkup(row_width=2)
             markup.add(
                 InlineKeyboardButton("👻 Yes, select ghosts", callback_data=f"ghost_yes_{rc_db_id}"),

--- a/tests/test_ghost_tracking.py
+++ b/tests/test_ghost_tracking.py
@@ -215,6 +215,24 @@ class TestErcGhostPrompt(GhostTestBase):
                  for i in range(self._sent_count())]
         self.assertFalse(any("👻" in t for t in texts))
 
+    async def test_no_ghost_prompt_for_pre_deployment_rollcall(self):
+        """Rollcalls that existed before deployment have absent_marked=True
+        and must never trigger the ghost prompt, even with IN users."""
+        from unittest.mock import MagicMock as MM
+        in_user = MM()
+        in_user.user_id = 5
+        self.rc.inList = [in_user]
+        self.rc.absent_marked = True  # simulates a pre-deployment rollcall
+
+        with self._rc_started(), \
+             patch('telegram_helper.admin_rights', new=AsyncMock(return_value=True)), \
+             patch('telegram_helper.manager', self.manager):
+            await self.th.end_roll_call(self._make_message("/erc"))
+
+        texts = [self.th.bot.send_message.call_args_list[i][0][1]
+                 for i in range(self._sent_count())]
+        self.assertFalse(any("👻" in t for t in texts))
+
 
 # ===========================================================================
 # 3. /in — reconfirmation triggered when ghost_count >= absent_limit


### PR DESCRIPTION
## Summary

- **Ghost Tracking**: After `/erc`, organiser is asked if anyone ghosted. Tap to select from the IN list. Selected users have their ghost count incremented in the DB.
- **Reconfirmation prompt**: Users who have ghosted ≥ `absent_limit` times receive a soft reconfirmation nudge when they vote IN again (can downgrade to Maybe/Out or confirm).
- **`/stats ghost`**: Public ghost leaderboard folded into the existing `/stats` command (aliases: `ghost`, `ghosts`, `absent`).
- **Admin commands**: `/toggle_ghost_tracking`, `/set_absent_limit <n>`, `/mark_absent` (retroactive marking), `/clear_absent <username>`.
- **Backward compatible**: On first startup `_migrate_schema()` stamps all pre-existing rollcalls as `absent_marked=TRUE` — the ghost prompt is never fired for sessions that ran before this deployment.
- **Default config**: Ghost tracking enabled by default; absent limit = 1 (admin-configurable per group).

## Test plan

- [x] 244/244 pytest tests pass (including new `TestErcGhostPrompt`, `TestInReconfirmation`, `TestGhostCallback*`, `TestStatsGhost`, `TestMarkAbsent`, `TestClearAbsent`, `TestGhostTrackingToggle`, `TestSetAbsentLimit`)
- [x] Pre-deployment rollcall guard tested: `test_no_ghost_prompt_for_pre_deployment_rollcall`
- [x] Existing handler tests unaffected
- [x] DB schema migration is additive (ALTER TABLE ADD COLUMN, safe on both SQLite and PostgreSQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)