### PR TITLE
feat: REST API auth — bearer tokens + scopes + rate limiting (slice 3)

### DIFF
--- a/integration_tests/test_api_auth.py
+++ b/integration_tests/test_api_auth.py
@@ -1,0 +1,241 @@
+"""
+Integration tests for REST API authentication, scopes, and rate limiting.
+
+Drives the real FastAPI app via TestClient. Mints / revokes tokens via
+db helpers. Verifies:
+  - Missing header → 401
+  - Bad / unknown token → 401
+  - Revoked token → 401
+  - Expired token → 401
+  - Token with wrong scope → 403
+  - Token bound to chat A used against chat B → 403
+  - Health is public (no auth required)
+  - Rate-limit fires at the configured threshold → 429 with Retry-After
+"""
+import os
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from mock_helpers import reset_db
+
+
+def _import():
+    import bot_state  # noqa: F401
+    import rollcall_manager
+    from api.main import app
+    from api.rate_limit import reset_buckets_for_tests
+    from db import (
+        _hash_token,
+        generate_api_token,
+        insert_api_token,
+        revoke_api_token,
+    )
+    return {
+        "app": app,
+        "manager": rollcall_manager.manager,
+        "reset_buckets_for_tests": reset_buckets_for_tests,
+        "_hash_token": _hash_token,
+        "generate_api_token": generate_api_token,
+        "insert_api_token": insert_api_token,
+        "revoke_api_token": revoke_api_token,
+    }
+
+
+CHAT_ID = -1001999000501
+OTHER_CHAT_ID = -1001999000502
+ALICE = {"id": 100, "name": "Alice", "username": "alice"}
+
+
+def _mint_token(chat_id: int, scopes: str, label: str = "test", expires_at=None) -> str:
+    """Issue a fresh token, return the plaintext."""
+    env = _import()
+    token = env["generate_api_token"]()
+    env["insert_api_token"](
+        env["_hash_token"](token),
+        chat_id,
+        scopes,
+        label=label,
+        issued_by_user_id=ALICE["id"],
+        expires_at=expires_at,
+    )
+    return token
+
+
+class AuthBase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.env = _import()
+        cls.app = cls.env["app"]
+        cls.manager = cls.env["manager"]
+        cls.client = TestClient(cls.app)
+
+    def setUp(self):
+        reset_db()
+        self.manager.clear_cache()
+        self.env["reset_buckets_for_tests"]()
+        # Clear any leftover default header from other test classes
+        self.client.headers.pop("Authorization", None)
+
+
+class TestNoAuthHeader(AuthBase):
+
+    def test_health_is_public(self):
+        r = self.client.get("/api/v1/health")
+        self.assertEqual(r.status_code, 200)
+
+    def test_protected_route_without_header_returns_401(self):
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/rollcalls")
+        self.assertEqual(r.status_code, 401)
+        self.assertIn("WWW-Authenticate", r.headers)
+
+
+class TestBadTokens(AuthBase):
+
+    def test_unknown_token_returns_401(self):
+        r = self.client.get(
+            f"/api/v1/chats/{CHAT_ID}/rollcalls",
+            headers={"Authorization": "Bearer rc_nonexistent_token_aaaaaaaa"},
+        )
+        self.assertEqual(r.status_code, 401)
+
+    def test_non_bearer_scheme_returns_401(self):
+        r = self.client.get(
+            f"/api/v1/chats/{CHAT_ID}/rollcalls",
+            headers={"Authorization": "Basic dXNlcjpwYXNz"},
+        )
+        self.assertEqual(r.status_code, 401)
+
+    def test_revoked_token_returns_401(self):
+        token = _mint_token(CHAT_ID, "read,vote,admin", label="will_revoke")
+        self.env["revoke_api_token"](self.env["_hash_token"](token))
+        r = self.client.get(
+            f"/api/v1/chats/{CHAT_ID}/rollcalls",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(r.status_code, 401)
+
+    def test_expired_token_returns_401(self):
+        expired_at = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=1)
+        token = _mint_token(CHAT_ID, "read", label="expired", expires_at=expired_at)
+        r = self.client.get(
+            f"/api/v1/chats/{CHAT_ID}/rollcalls",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(r.status_code, 401)
+
+
+class TestScopes(AuthBase):
+
+    def test_read_token_can_get_but_not_post(self):
+        token = _mint_token(CHAT_ID, "read", label="readonly")
+        h = {"Authorization": f"Bearer {token}"}
+        # GET is allowed
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/rollcalls", headers=h)
+        self.assertEqual(r.status_code, 200)
+        # POST is forbidden
+        r2 = self.client.post(
+            f"/api/v1/chats/{CHAT_ID}/rollcalls",
+            json={
+                "title": "X",
+                "started_by_user_id": ALICE["id"],
+                "started_by_name": ALICE["name"],
+            },
+            headers=h,
+        )
+        self.assertEqual(r2.status_code, 403)
+
+    def test_vote_token_can_post_but_not_delete(self):
+        token = _mint_token(CHAT_ID, "read,vote", label="voter")
+        h = {"Authorization": f"Bearer {token}"}
+        # Need an active rollcall first to attempt DELETE
+        self.client.post(
+            f"/api/v1/chats/{CHAT_ID}/rollcalls",
+            json={
+                "title": "X",
+                "started_by_user_id": ALICE["id"],
+                "started_by_name": ALICE["name"],
+            },
+            headers=h,
+        )
+        # DELETE requires 'admin'
+        r = self.client.request(
+            "DELETE",
+            f"/api/v1/chats/{CHAT_ID}/rollcalls/1",
+            json={"ended_by_user_id": ALICE["id"], "ended_by_name": ALICE["name"]},
+            headers=h,
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_admin_token_implies_lower_scopes(self):
+        token = _mint_token(CHAT_ID, "admin", label="god")
+        h = {"Authorization": f"Bearer {token}"}
+        # admin can GET (would normally need 'read')
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/rollcalls", headers=h)
+        self.assertEqual(r.status_code, 200)
+        # admin can POST (would normally need 'vote')
+        r2 = self.client.post(
+            f"/api/v1/chats/{CHAT_ID}/rollcalls",
+            json={
+                "title": "X",
+                "started_by_user_id": ALICE["id"],
+                "started_by_name": ALICE["name"],
+            },
+            headers=h,
+        )
+        self.assertEqual(r2.status_code, 201)
+
+
+class TestCrossChatIsolation(AuthBase):
+
+    def test_token_for_chat_A_cannot_operate_on_chat_B(self):
+        token = _mint_token(CHAT_ID, "admin", label="A-only")
+        h = {"Authorization": f"Bearer {token}"}
+        r = self.client.get(f"/api/v1/chats/{OTHER_CHAT_ID}/rollcalls", headers=h)
+        self.assertEqual(r.status_code, 403)
+
+
+class TestRateLimit(AuthBase):
+
+    def setUp(self):
+        super().setUp()
+        # Force a low limit for these tests; lift after each test
+        self._old_max = os.environ.get("REST_API_RATE_LIMIT_MAX_REQUESTS")
+        self._old_window = os.environ.get("REST_API_RATE_LIMIT_WINDOW_SECONDS")
+        os.environ["REST_API_RATE_LIMIT_MAX_REQUESTS"] = "3"
+        os.environ["REST_API_RATE_LIMIT_WINDOW_SECONDS"] = "60"
+
+    def tearDown(self):
+        for k, v in (
+            ("REST_API_RATE_LIMIT_MAX_REQUESTS", self._old_max),
+            ("REST_API_RATE_LIMIT_WINDOW_SECONDS", self._old_window),
+        ):
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_rate_limit_returns_429_after_threshold(self):
+        token = _mint_token(CHAT_ID, "read", label="ratelim")
+        h = {"Authorization": f"Bearer {token}"}
+        # Within limit (3)
+        for _ in range(3):
+            r = self.client.get(f"/api/v1/chats/{CHAT_ID}/rollcalls", headers=h)
+            self.assertEqual(r.status_code, 200)
+        # 4th request hits the cap
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/rollcalls", headers=h)
+        self.assertEqual(r.status_code, 429)
+        self.assertIn("Retry-After", r.headers)
+        self.assertEqual(r.json()["error"], "rateLimitExceeded")
+
+    def test_rate_limit_skips_health_endpoint(self):
+        # Hammer /health well past the limit — should never 429
+        for _ in range(10):
+            r = self.client.get("/api/v1/health")
+            self.assertEqual(r.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integration_tests/test_api_rollcalls.py
+++ b/integration_tests/test_api_rollcalls.py
@@ -21,7 +21,14 @@ def _import():
     import bot_state  # noqa: F401  warm conftest's mock graph
     import rollcall_manager
     from api.main import app
-    return {"app": app, "manager": rollcall_manager.manager}
+    from db import _hash_token, generate_api_token, insert_api_token
+    return {
+        "app": app,
+        "manager": rollcall_manager.manager,
+        "generate_api_token": generate_api_token,
+        "insert_api_token": insert_api_token,
+        "_hash_token": _hash_token,
+    }
 
 
 CHAT_ID = -1001999000701
@@ -40,6 +47,18 @@ class APIBase(unittest.TestCase):
     def setUp(self):
         reset_db()
         self.manager.clear_cache()
+        # Reset rate-limit buckets so test order doesn't pollute counts.
+        from api.rate_limit import reset_buckets_for_tests
+        reset_buckets_for_tests()
+        # Issue a full-scope token for CHAT_ID and set it as the
+        # client's default header so every existing test request
+        # auto-authenticates. Tests that want to override (or omit)
+        # auth set/clear `self.client.headers["Authorization"]`.
+        from db import _hash_token, generate_api_token, insert_api_token
+        token = generate_api_token()
+        insert_api_token(_hash_token(token), CHAT_ID, "read,vote,admin",
+                         label="test", issued_by_user_id=ALICE["id"])
+        self.client.headers["Authorization"] = f"Bearer {token}"
 
 
 class TestHealthRoute(APIBase):

--- a/integration_tests/test_api_votes.py
+++ b/integration_tests/test_api_votes.py
@@ -13,7 +13,14 @@ def _import():
     import bot_state  # noqa: F401  warm conftest mocks
     import rollcall_manager
     from api.main import app
-    return {"app": app, "manager": rollcall_manager.manager}
+    from db import _hash_token, generate_api_token, insert_api_token
+    return {
+        "app": app,
+        "manager": rollcall_manager.manager,
+        "generate_api_token": generate_api_token,
+        "insert_api_token": insert_api_token,
+        "_hash_token": _hash_token,
+    }
 
 
 CHAT_ID = -1001999000601
@@ -35,6 +42,14 @@ class VotesAPIBase(unittest.TestCase):
     def setUp(self):
         reset_db()
         self.manager.clear_cache()
+        from api.rate_limit import reset_buckets_for_tests
+        reset_buckets_for_tests()
+        # Auto-auth all requests for this base
+        from db import _hash_token, generate_api_token, insert_api_token
+        token = generate_api_token()
+        insert_api_token(_hash_token(token), CHAT_ID, "read,vote,admin",
+                         label="test", issued_by_user_id=ALICE["id"])
+        self.client.headers["Authorization"] = f"Bearer {token}"
         # Start a rollcall for every test
         self.client.post(
             f"/api/v1/chats/{CHAT_ID}/rollcalls",

--- a/rollCall/api/auth.py
+++ b/rollCall/api/auth.py
@@ -1,0 +1,134 @@
+"""
+Bearer-token authentication for the REST API.
+
+Tokens are issued out-of-band (CLI script in `scripts/issue_api_token.py`)
+and presented by clients via the `Authorization: Bearer <token>` header.
+
+Scopes:
+  read   — read-only endpoints (GET rollcalls, GET single rollcall)
+  vote   — voting + creating rollcalls (POST routes)
+  admin  — destructive ops (DELETE rollcall) and future settings mutations
+
+Tokens are scoped to a single chat (`chat_id` on the row). Routes that
+take `chat_id` from the URL path also verify that the token's chat_id
+matches — i.e. a token issued for chat A can't operate on chat B even
+with the right scope.
+
+Usage in a route:
+
+    from api.auth import require_scope, AuthedToken
+
+    @router.post(...)
+    async def create_rollcall(
+        ...,
+        token: AuthedToken = Depends(require_scope("vote")),
+    ):
+        # token.chat_id is the chat the token is bound to
+        ...
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from db import _hash_token, lookup_api_token
+
+
+# auto_error=False so we can return our own JSON error instead of
+# FastAPI's default {"detail": "Not authenticated"} string.
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+@dataclass
+class AuthedToken:
+    """The verified token's claims, attached to the request via Depends."""
+
+    chat_id: int
+    scopes: List[str]
+    label: Optional[str]
+    issued_by_user_id: Optional[int]
+
+
+def _unauthorized(detail: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=detail,
+        headers={"WWW-Authenticate": 'Bearer realm="rollcall"'},
+    )
+
+
+def _forbidden(detail: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=detail,
+    )
+
+
+def _verify_token(creds: Optional[HTTPAuthorizationCredentials]) -> AuthedToken:
+    """Look up the supplied bearer token, raising HTTPException on failure."""
+    if creds is None or not creds.credentials:
+        raise _unauthorized("Missing Authorization: Bearer <token> header")
+    if creds.scheme.lower() != "bearer":
+        raise _unauthorized("Authorization scheme must be 'Bearer'")
+
+    row = lookup_api_token(_hash_token(creds.credentials))
+    if row is None:
+        # Don't distinguish "unknown" from "expired" from "revoked" — same
+        # 401 for all so clients can't probe token state.
+        raise _unauthorized("Invalid or expired token")
+
+    return AuthedToken(
+        chat_id=int(row["chat_id"]),
+        scopes=row["scopes"],
+        label=row.get("label"),
+        issued_by_user_id=row.get("issued_by_user_id"),
+    )
+
+
+def require_scope(scope: str):
+    """
+    Dependency factory: returns a FastAPI dependency that verifies a
+    bearer token and asserts the token has the required scope. The
+    chat_id-from-URL match check happens here too if `chat_id` is in
+    the request path.
+
+    Tokens with the `admin` scope implicitly satisfy any other scope —
+    admin is a superset.
+    """
+
+    async def _dep(
+        request: Request,
+        creds: Optional[HTTPAuthorizationCredentials] = Depends(_bearer_scheme),
+    ) -> AuthedToken:
+        token = _verify_token(creds)
+
+        if scope not in token.scopes and "admin" not in token.scopes:
+            raise _forbidden(
+                f"Token lacks required scope '{scope}' "
+                f"(has: {','.join(token.scopes) or 'none'})"
+            )
+
+        # Cross-chat check: if the URL path includes chat_id, it must
+        # match the token's bound chat_id. This stops a token issued for
+        # chat A from operating on chat B even with the right scope.
+        path_chat_id = request.path_params.get("chat_id")
+        if path_chat_id is not None:
+            try:
+                if int(path_chat_id) != token.chat_id:
+                    raise _forbidden(
+                        f"Token bound to chat {token.chat_id}, "
+                        f"cannot operate on chat {path_chat_id}"
+                    )
+            except (TypeError, ValueError):
+                # path_chat_id is non-int — FastAPI's int converter should
+                # already reject this before us, but guard anyway.
+                raise _forbidden("chat_id in URL is invalid")
+
+        # Attach the token to the request so middleware (e.g. rate-limit)
+        # can read it without a second DB lookup.
+        request.state.api_token = token
+        return token
+
+    return _dep

--- a/rollCall/api/main.py
+++ b/rollCall/api/main.py
@@ -26,6 +26,7 @@ from exceptions import (
     rollCallAlreadyStarted,
     rollCallNotStarted,
 )
+from api.rate_limit import rate_limit_middleware
 from api.routes import health, rollcalls, votes
 from api.schemas.common import ErrorResponse
 
@@ -89,6 +90,9 @@ def create_app() -> FastAPI:
                 detail=str(exc) or type(exc).__name__,
             ).model_dump(),
         )
+
+    # Rate-limit middleware. Runs before routes; skips /health.
+    app.middleware("http")(rate_limit_middleware)
 
     # Route mounting
     app.include_router(health.router, prefix=API_PREFIX, tags=["health"])

--- a/rollCall/api/rate_limit.py
+++ b/rollCall/api/rate_limit.py
@@ -1,0 +1,99 @@
+"""
+Per-token sliding-window rate limiter.
+
+In-memory, keyed by the token's SHA-256 hash (so unauthenticated requests
+share a single anonymous bucket and are throttled aggressively to dampen
+unauth flood patterns).
+
+State is lost on bot restart — acceptable for the protection level we
+need here. If burst patterns become a real concern we move to Redis.
+The window and per-window limit are env-configurable:
+
+  REST_API_RATE_LIMIT_WINDOW_SECONDS=60   (default 60s)
+  REST_API_RATE_LIMIT_MAX_REQUESTS=60     (default 60 requests / window)
+
+Skips paths in `_BYPASS_PATHS` (currently /health and OpenAPI metadata).
+"""
+
+import os
+import time
+from collections import defaultdict, deque
+from typing import Deque, Dict
+
+from fastapi import Request, status
+from fastapi.responses import JSONResponse
+
+
+_BYPASS_PATHS = (
+    "/api/v1/health",
+    "/api/v1/openapi.json",
+    "/api/docs",
+    "/api/redoc",
+    "/docs/oauth2-redirect",
+)
+
+
+def _settings() -> tuple[int, int]:
+    """(window_seconds, max_requests). Read every call so tests can mutate
+    env between runs; cost is negligible vs the cost of a rate decision."""
+    window = int(os.environ.get("REST_API_RATE_LIMIT_WINDOW_SECONDS", "60"))
+    maxreq = int(os.environ.get("REST_API_RATE_LIMIT_MAX_REQUESTS", "60"))
+    return window, maxreq
+
+
+# Per-key timestamp deques. Each entry is a unix timestamp of a request.
+# We trim from the left to drop entries older than the window.
+_buckets: Dict[str, Deque[float]] = defaultdict(deque)
+
+
+def reset_buckets_for_tests() -> None:
+    """Test-only: clear all rate-limit state. Avoid mutating _buckets
+    directly from tests so we can change the implementation freely."""
+    _buckets.clear()
+
+
+def _bucket_key(request: Request) -> str:
+    """
+    Choose a bucket key. Prefer the authed token's hash (set on
+    request.state by api.auth.require_scope). Falls back to client IP
+    so unauthenticated requests still get a (shared, aggressive) cap.
+    """
+    token = getattr(request.state, "api_token", None)
+    if token is not None:
+        # Use chat_id + label as a stable handle without re-hashing.
+        return f"token:{token.chat_id}:{token.label or ''}"
+    client = request.client
+    return f"ip:{client.host if client else 'unknown'}"
+
+
+async def rate_limit_middleware(request: Request, call_next):
+    """ASGI middleware: enforce per-bucket sliding window."""
+    if request.url.path in _BYPASS_PATHS:
+        return await call_next(request)
+
+    window, maxreq = _settings()
+    now = time.monotonic()
+    cutoff = now - window
+
+    key = _bucket_key(request)
+    bucket = _buckets[key]
+
+    # Trim expired entries (entries older than `window` seconds ago).
+    while bucket and bucket[0] < cutoff:
+        bucket.popleft()
+
+    if len(bucket) >= maxreq:
+        # Oldest entry in the bucket dictates how soon the client can retry.
+        retry_after = max(1, int(bucket[0] + window - now) + 1)
+        return JSONResponse(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            content={
+                "error": "rateLimitExceeded",
+                "detail": f"Rate limit: {maxreq} requests / {window}s. "
+                          f"Retry after {retry_after}s.",
+            },
+            headers={"Retry-After": str(retry_after)},
+        )
+
+    bucket.append(now)
+    return await call_next(request)

--- a/rollCall/api/routes/rollcalls.py
+++ b/rollCall/api/routes/rollcalls.py
@@ -10,10 +10,11 @@ service which expects 0-based.
 
 from typing import List
 
-from fastapi import APIRouter, Path, status
+from fastapi import APIRouter, Depends, Path, status
 
 from services import rollcalls as rc_svc
 
+from api.auth import AuthedToken, require_scope
 from api.schemas.rollcalls import (
     EndRollcallRequest,
     EndRollcallResponse,
@@ -34,6 +35,7 @@ router = APIRouter()
 async def start_rollcall(
     body: StartRollcallRequest,
     chat_id: int = Path(..., description="Telegram chat id"),
+    _token: AuthedToken = Depends(require_scope("vote")),
 ) -> RollcallResponse:
     result = await rc_svc.start_rollcall(
         chat_id=chat_id,
@@ -52,6 +54,7 @@ async def start_rollcall(
 )
 async def list_rollcalls(
     chat_id: int = Path(..., description="Telegram chat id"),
+    _token: AuthedToken = Depends(require_scope("read")),
 ) -> List[RollcallResponse]:
     return [RollcallResponse(**r) for r in rc_svc.list_rollcalls(chat_id)]
 
@@ -64,6 +67,7 @@ async def list_rollcalls(
 async def get_rollcall(
     chat_id: int = Path(..., description="Telegram chat id"),
     rc_number: int = Path(..., ge=1, description="1-based rollcall number"),
+    _token: AuthedToken = Depends(require_scope("read")),
 ) -> RollcallResponse:
     return RollcallResponse(**rc_svc.get_rollcall(chat_id, rc_number - 1))
 
@@ -77,6 +81,7 @@ async def end_rollcall(
     body: EndRollcallRequest,
     chat_id: int = Path(..., description="Telegram chat id"),
     rc_number: int = Path(..., ge=1, description="1-based rollcall number"),
+    _token: AuthedToken = Depends(require_scope("admin")),
 ) -> EndRollcallResponse:
     result = await rc_svc.end_rollcall(
         chat_id=chat_id,

--- a/rollCall/api/routes/votes.py
+++ b/rollCall/api/routes/votes.py
@@ -7,10 +7,11 @@ simple (no /vote-in, /vote-out, etc.) while still letting clients
 explicitly express what they want.
 """
 
-from fastapi import APIRouter, HTTPException, Path, status
+from fastapi import APIRouter, Depends, HTTPException, Path, status
 
 from services import voting as vote_svc
 
+from api.auth import AuthedToken, require_scope
 from api.schemas.votes import VoteRequest, VoteResponse
 
 
@@ -27,6 +28,7 @@ async def cast_vote(
     body: VoteRequest,
     chat_id: int = Path(..., description="Telegram chat id"),
     rc_number: int = Path(..., ge=1, description="1-based rollcall number"),
+    _token: AuthedToken = Depends(require_scope("vote")),
 ) -> VoteResponse:
     common_args = dict(
         chat_id=chat_id,

--- a/rollCall/db.py
+++ b/rollCall/db.py
@@ -595,6 +595,46 @@ def create_tables():
                 )
             """)
 
+        # api_tokens: bearer tokens for REST API auth (PR 3).
+        # Only the SHA-256 hash of the token is stored — plaintext is
+        # shown to the issuer exactly once at creation and discarded.
+        if db_type == 'postgresql':
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS api_tokens (
+                    token_hash TEXT PRIMARY KEY,
+                    chat_id BIGINT NOT NULL,
+                    issued_by_user_id BIGINT,
+                    scopes TEXT NOT NULL,
+                    label TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    expires_at TIMESTAMP,
+                    last_used_at TIMESTAMP,
+                    revoked_at TIMESTAMP
+                )
+            """)
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_api_tokens_chat
+                ON api_tokens(chat_id)
+            """)
+        else:
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS api_tokens (
+                    token_hash TEXT PRIMARY KEY,
+                    chat_id INTEGER NOT NULL,
+                    issued_by_user_id INTEGER,
+                    scopes TEXT NOT NULL,
+                    label TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    expires_at TIMESTAMP,
+                    last_used_at TIMESTAMP,
+                    revoked_at TIMESTAMP
+                )
+            """)
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_api_tokens_chat
+                ON api_tokens(chat_id)
+            """)
+
         conn.commit()
         logging.debug("Database tables created successfully")
 
@@ -3444,6 +3484,173 @@ def get_active_members(chat_id: int) -> List[Dict]:
     except Exception as e:
         logging.error(f"Error getting active members: {e}")
         return []
+    finally:
+        if cursor is not None:
+            cursor.close()
+        if db_type == 'postgresql':
+            release_connection(conn)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# api_tokens CRUD (REST API auth — PR 3)
+# ────────────────────────────────────────────────────────────────────────
+
+import hashlib  # noqa: E402
+import secrets  # noqa: E402
+
+
+def _hash_token(token: str) -> str:
+    """SHA-256 hex digest of an API token. The plaintext is never stored;
+    callers verify by hashing the inbound token and looking up by hash.
+    Token entropy is high enough (>=128 bits) that no salt is needed.
+    """
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def generate_api_token() -> str:
+    """Generate a new opaque API token. Format: `rc_<32 hex>` (132 bits
+    of entropy from secrets). Plaintext is shown to the issuer once."""
+    return f"rc_{secrets.token_hex(16)}"
+
+
+def insert_api_token(
+    token_hash: str,
+    chat_id: int,
+    scopes: str,
+    label: str | None = None,
+    issued_by_user_id: int | None = None,
+    expires_at=None,
+) -> None:
+    """Persist an issued token's hash, scopes, and metadata. The plaintext
+    must NOT be passed here — it's the caller's responsibility to hash."""
+    conn = get_connection()
+    cursor = None
+    try:
+        cursor = conn.cursor()
+        ph = '%s' if db_type == 'postgresql' else '?'
+        cursor.execute(f"""
+            INSERT INTO api_tokens (token_hash, chat_id, issued_by_user_id,
+                                    scopes, label, expires_at)
+            VALUES ({ph}, {ph}, {ph}, {ph}, {ph}, {ph})
+        """, (token_hash, chat_id, issued_by_user_id, scopes, label, expires_at))
+        conn.commit()
+    finally:
+        if cursor is not None:
+            cursor.close()
+        if db_type == 'postgresql':
+            release_connection(conn)
+
+
+def lookup_api_token(token_hash: str) -> Optional[Dict]:
+    """Look up a token by its hash. Returns a dict with chat_id, scopes
+    (parsed to a list), label, expires_at, revoked_at — or None if no
+    matching token, the token is revoked, or it has expired.
+
+    Also bumps `last_used_at` as a side effect when a hit is returned, so
+    operators can audit token activity via the same row."""
+    conn = get_connection()
+    cursor = None
+    try:
+        cursor = conn.cursor()
+        ph = '%s' if db_type == 'postgresql' else '?'
+        cursor.execute(f"""
+            SELECT chat_id, issued_by_user_id, scopes, label,
+                   created_at, expires_at, last_used_at, revoked_at
+            FROM api_tokens
+            WHERE token_hash = {ph}
+        """, (token_hash,))
+        row = cursor.fetchone()
+        if row is None:
+            return None
+
+        d = dict(row)
+        # Revoked or expired tokens act as non-existent for auth purposes.
+        if d.get("revoked_at") is not None:
+            return None
+        expires_at = d.get("expires_at")
+        if expires_at is not None:
+            # PG returns datetime; SQLite returns string. Coerce to compare.
+            from datetime import datetime, timezone
+            now = datetime.now(timezone.utc).replace(tzinfo=None)
+            try:
+                if isinstance(expires_at, str):
+                    parsed = _parse_db_datetime(expires_at)
+                else:
+                    parsed = expires_at
+                if parsed is not None and parsed < now:
+                    return None
+            except Exception:
+                logging.exception("api_token expiry parse failed; treating as expired")
+                return None
+
+        # Bump last_used_at. Best-effort — don't fail the lookup if it fails.
+        try:
+            cursor.execute(f"""
+                UPDATE api_tokens SET last_used_at = CURRENT_TIMESTAMP
+                WHERE token_hash = {ph}
+            """, (token_hash,))
+            conn.commit()
+        except Exception:
+            logging.exception("api_token last_used_at update failed")
+
+        d["scopes"] = [s.strip() for s in (d.get("scopes") or "").split(",") if s.strip()]
+        return d
+    except Exception:
+        logging.exception("lookup_api_token failed")
+        return None
+    finally:
+        if cursor is not None:
+            cursor.close()
+        if db_type == 'postgresql':
+            release_connection(conn)
+
+
+def list_api_tokens(chat_id: int) -> List[Dict]:
+    """List all tokens issued for a chat (active + revoked + expired).
+    Useful for the admin token-management surface. token_hash is included
+    so revocation by hash works."""
+    conn = get_connection()
+    cursor = None
+    try:
+        cursor = conn.cursor()
+        ph = '%s' if db_type == 'postgresql' else '?'
+        cursor.execute(f"""
+            SELECT token_hash, issued_by_user_id, scopes, label,
+                   created_at, expires_at, last_used_at, revoked_at
+            FROM api_tokens
+            WHERE chat_id = {ph}
+            ORDER BY created_at DESC
+        """, (chat_id,))
+        return [dict(row) for row in cursor.fetchall()]
+    except Exception:
+        logging.exception("list_api_tokens failed")
+        return []
+    finally:
+        if cursor is not None:
+            cursor.close()
+        if db_type == 'postgresql':
+            release_connection(conn)
+
+
+def revoke_api_token(token_hash: str) -> bool:
+    """Mark a token as revoked (sets revoked_at). Returns True if a row
+    was modified, False if no such token (or already revoked)."""
+    conn = get_connection()
+    cursor = None
+    try:
+        cursor = conn.cursor()
+        ph = '%s' if db_type == 'postgresql' else '?'
+        cursor.execute(f"""
+            UPDATE api_tokens
+            SET revoked_at = CURRENT_TIMESTAMP
+            WHERE token_hash = {ph} AND revoked_at IS NULL
+        """, (token_hash,))
+        affected = cursor.rowcount
+        conn.commit()
+        return bool(affected)
+    except Exception:
+        logging.exception("revoke_api_token failed")
+        return False
     finally:
         if cursor is not None:
             cursor.close()

--- a/scripts/issue_api_token.py
+++ b/scripts/issue_api_token.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Issue a new REST API token for a chat.
+
+Run this on the bot's host (the script needs DATABASE_URL pointing at the
+same DB the bot uses, or it falls back to sqlite:///rollcall.db). Prints
+the plaintext token exactly once — store it immediately, the bot only
+keeps the SHA-256 hash.
+
+Usage:
+    python scripts/issue_api_token.py \\
+        --chat-id -1001999000001 \\
+        --scopes read,vote,admin \\
+        --label "Webapp prod" \\
+        [--expires-days 30] \\
+        [--issued-by 168415137]
+
+When scopes are omitted, defaults to 'read,vote' (no admin). Tokens with
+the 'admin' scope can DELETE rollcalls and (in future PRs) mutate chat
+settings, so issue them sparingly.
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--chat-id", type=int, required=True,
+                        help="Telegram chat id the token will be scoped to")
+    parser.add_argument("--scopes", default="read,vote",
+                        help="Comma-separated scopes: read, vote, admin (default: read,vote)")
+    parser.add_argument("--label", default=None,
+                        help="Friendly name shown in token listings (e.g. 'Webapp prod')")
+    parser.add_argument("--expires-days", type=int, default=None,
+                        help="Token expires after this many days (default: no expiry)")
+    parser.add_argument("--issued-by", type=int, default=None,
+                        help="Telegram user id of the issuer (audit only)")
+    args = parser.parse_args()
+
+    valid_scopes = {"read", "vote", "admin"}
+    requested = [s.strip() for s in args.scopes.split(",") if s.strip()]
+    invalid = [s for s in requested if s not in valid_scopes]
+    if invalid:
+        print(f"ERROR: unknown scope(s): {invalid}. Valid: read, vote, admin.", file=sys.stderr)
+        return 2
+    if not requested:
+        print("ERROR: at least one scope is required.", file=sys.stderr)
+        return 2
+
+    # rollCall package needs to be importable
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    sys.path.insert(0, os.path.join(repo_root, "rollCall"))
+
+    # We don't want bot_state to construct a real AsyncTeleBot, so set a
+    # dummy token if none configured.
+    os.environ.setdefault("TELEGRAM_TOKEN", "dummy:for_token_issue")
+
+    from db import _hash_token, generate_api_token, insert_api_token  # noqa: E402
+
+    token = generate_api_token()
+    token_hash = _hash_token(token)
+    expires_at = None
+    if args.expires_days is not None:
+        expires_at = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=args.expires_days)
+
+    insert_api_token(
+        token_hash=token_hash,
+        chat_id=args.chat_id,
+        scopes=",".join(sorted(set(requested))),
+        label=args.label,
+        issued_by_user_id=args.issued_by,
+        expires_at=expires_at,
+    )
+
+    print("=" * 60)
+    print("Token issued. Store this NOW — it is not recoverable.")
+    print("=" * 60)
+    print(f"  Chat id:    {args.chat_id}")
+    print(f"  Scopes:     {','.join(sorted(set(requested)))}")
+    if args.label:
+        print(f"  Label:      {args.label}")
+    if expires_at:
+        print(f"  Expires:    {expires_at.isoformat()} UTC")
+    if args.issued_by:
+        print(f"  Issued by:  {args.issued_by}")
+    print()
+    print(f"  Token:      {token}")
+    print()
+    print("Use it as:")
+    print(f'  curl -H "Authorization: Bearer {token}" \\')
+    print(f"       http://localhost:8081/api/v1/chats/{args.chat_id}/rollcalls")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Third slice of the REST API plan. Adds bearer-token authentication, per-route scope checks, and a per-token sliding-window rate limit. **Bot is unchanged at runtime.**

## What's in this PR

\`\`\`
rollCall/db.py                       + api_tokens table + CRUD
rollCall/api/auth.py                 HTTPBearer + require_scope() factory
rollCall/api/rate_limit.py           sliding-window middleware (60 req / 60s default)
rollCall/api/routes/*                each route declares Depends(require_scope(...))
scripts/issue_api_token.py           CLI to mint tokens
integration_tests/test_api_auth.py   (+12 tests)
\`\`\`

## Scope mapping

| Route | Scope |
|---|---|
| \`GET\` rollcalls / rollcall / health | \`read\` (health is public) |
| \`POST\` rollcalls / votes | \`vote\` |
| \`DELETE\` rollcalls/{n} | \`admin\` (destructive) |

\`admin\` is a superset — implicitly satisfies \`read\` and \`vote\`.

## Security posture

- Tokens stored as SHA-256 hash; plaintext shown to issuer once
- Tokens scoped to one \`chat_id\` — token issued for chat A cannot operate on chat B (verified by route)
- Rate limit defaults: 60 requests / 60s per token, configurable via env (\`REST_API_RATE_LIMIT_MAX_REQUESTS\` / \`..._WINDOW_SECONDS\`)
- Unauthenticated requests share an IP bucket (aggressive default)
- 401 returned for unknown/expired/revoked (don't probe token state)
- 403 for wrong scope or cross-chat use

## Token issuance

CLI only in this PR:
\`\`\`bash
python scripts/issue_api_token.py \\
    --chat-id -1001999000001 \\
    --scopes read,vote \\
    --label "Webapp prod" \\
    --expires-days 30
\`\`\`
Prints plaintext exactly once. A bot-side \`/api_token\` admin command can land in a follow-up PR.

## Test plan

- [x] \`smoke_test.py\` — 9/9
- [x] \`pytest tests/\` — 298/298 (unchanged)
- [x] \`pytest integration_tests/\` — **468/468** (was 456; +12 auth tests)
- [x] \`functional_test_4_34.py\` — 121/121
- [x] \`verify_persistence.py\` — 44/44
- [ ] CI green

## Next

| Slice | What |
|---|---|
| **PR 4** | Services for templates / stats / proxy / ghost / settings + REST routes |
| PR 5 (optional) | Refactor bot handlers to use services |