### PR TITLE
feat: proxy services + REST route (slice 4a)

### DIFF
--- a/integration_tests/test_api_proxy_votes.py
+++ b/integration_tests/test_api_proxy_votes.py
@@ -1,0 +1,147 @@
+"""
+Integration tests for the proxy-vote route (POST /chats/{id}/rollcalls/{n}/proxy-votes).
+
+Real services + real DB via FastAPI TestClient. Auth + rate-limit reset
+per test (mirrors the pattern in test_api_votes.py).
+"""
+import unittest
+
+from fastapi.testclient import TestClient
+
+from mock_helpers import reset_db
+
+
+def _import():
+    import bot_state  # noqa: F401
+    import rollcall_manager
+    from api.main import app
+    return {"app": app, "manager": rollcall_manager.manager}
+
+
+CHAT_ID = -1001999000301
+ALICE = {"id": 100, "name": "Alice", "username": "alice"}
+
+
+class ProxyVotesAPIBase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        env = _import()
+        cls.app = env["app"]
+        cls.manager = env["manager"]
+        cls.client = TestClient(cls.app)
+
+    def setUp(self):
+        reset_db()
+        self.manager.clear_cache()
+        from api.rate_limit import reset_buckets_for_tests
+        reset_buckets_for_tests()
+        from db import _hash_token, generate_api_token, insert_api_token
+        token = generate_api_token()
+        insert_api_token(_hash_token(token), CHAT_ID, "read,vote,admin",
+                         label="test", issued_by_user_id=ALICE["id"])
+        self.client.headers["Authorization"] = f"Bearer {token}"
+        # Start a rollcall for every test
+        self.client.post(
+            f"/api/v1/chats/{CHAT_ID}/rollcalls",
+            json={
+                "title": "Match",
+                "started_by_user_id": ALICE["id"],
+                "started_by_name": ALICE["name"],
+                "started_by_username": ALICE["username"],
+            },
+        )
+
+    def _proxy_vote(self, choice, name, comment=None, rc_number=1):
+        return self.client.post(
+            f"/api/v1/chats/{CHAT_ID}/rollcalls/{rc_number}/proxy-votes",
+            json={
+                "vote": choice,
+                "proxy_name": name,
+                "admin_user_id": ALICE["id"],
+                "admin_name": ALICE["name"],
+                "comment": comment,
+            },
+        )
+
+
+class TestProxyIn(ProxyVotesAPIBase):
+
+    def test_proxy_in_returns_201(self):
+        r = self._proxy_vote("in", "Alex")
+        self.assertEqual(r.status_code, 201)
+        body = r.json()
+        self.assertEqual(body["action"], "added")
+        self.assertEqual(body["user"]["name"], "Alex")
+        self.assertTrue(body["user"]["is_proxy"])
+        self.assertEqual(body["proxy_owner_id"], ALICE["id"])
+
+    def test_proxy_in_with_comment(self):
+        r = self._proxy_vote("in", "Alex", comment="bringing snacks")
+        self.assertEqual(r.status_code, 201)
+        self.assertEqual(r.json()["user"]["comment"], "bringing snacks")
+
+    def test_proxy_in_duplicate_returns_409(self):
+        self._proxy_vote("in", "Alex")
+        r = self._proxy_vote("in", "Alex")
+        self.assertEqual(r.status_code, 409)
+        self.assertEqual(r.json()["error"], "duplicateProxy")
+
+    def test_proxy_in_long_name_returns_422_pydantic(self):
+        # Pydantic max_length=40 catches it before service
+        r = self._proxy_vote("in", "X" * 60)
+        self.assertEqual(r.status_code, 422)
+
+
+class TestProxyOutAndMaybe(ProxyVotesAPIBase):
+
+    def test_proxy_out_fresh(self):
+        r = self._proxy_vote("out", "Alex")
+        self.assertEqual(r.status_code, 201)
+        body = r.json()
+        self.assertEqual(body["action"], "added")
+        self.assertFalse(body["was_in"])
+        out_names = [u["name"] for u in body["rollcall"]["out_list"]]
+        self.assertIn("Alex", out_names)
+
+    def test_proxy_out_promotes_waitlister(self):
+        rc = self.manager.get_rollcall(CHAT_ID, 0)
+        rc.inListLimit = 1
+        rc.save()
+        self._proxy_vote("in", "Alex")
+        self._proxy_vote("in", "Brian")  # waitlists
+        r = self._proxy_vote("out", "Alex")
+        body = r.json()
+        self.assertEqual(body["action"], "moved")
+        self.assertEqual(body["promoted"]["name"], "Brian")
+
+    def test_proxy_maybe_fresh(self):
+        r = self._proxy_vote("maybe", "Alex")
+        self.assertEqual(r.status_code, 201)
+        maybe_names = [u["name"] for u in r.json()["rollcall"]["maybe_list"]]
+        self.assertIn("Alex", maybe_names)
+
+
+class TestProxyAuth(ProxyVotesAPIBase):
+
+    def test_proxy_vote_requires_vote_scope(self):
+        # Issue a read-only token and try
+        from db import _hash_token, generate_api_token, insert_api_token
+        ro = generate_api_token()
+        insert_api_token(_hash_token(ro), CHAT_ID, "read",
+                         label="readonly", issued_by_user_id=ALICE["id"])
+        r = self.client.post(
+            f"/api/v1/chats/{CHAT_ID}/rollcalls/1/proxy-votes",
+            json={
+                "vote": "in",
+                "proxy_name": "Alex",
+                "admin_user_id": ALICE["id"],
+                "admin_name": ALICE["name"],
+            },
+            headers={"Authorization": f"Bearer {ro}"},
+        )
+        self.assertEqual(r.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integration_tests/test_services_proxy.py
+++ b/integration_tests/test_services_proxy.py
@@ -1,0 +1,223 @@
+"""
+Unit tests for rollCall/services/proxy.py — set_in_for, set_out_for,
+set_maybe_for, check_proxy_ghost_reconfirmation_needed.
+
+Real SQLite + real RollCallManager. Telebot mocked by conftest.
+"""
+import unittest
+
+from mock_helpers import reset_db
+
+
+def _import():
+    import bot_state  # noqa: F401  warm conftest mocks
+    import rollcall_manager
+    from services import proxy as proxy_svc
+    from services import rollcalls as rc_svc
+    from services import voting as vote_svc
+    from exceptions import (
+        duplicateProxy,
+        incorrectParameter,
+        parameterMissing,
+        repeatlyName,
+        rollCallNotStarted,
+    )
+    return {
+        "proxy_svc": proxy_svc,
+        "rc_svc": rc_svc,
+        "vote_svc": vote_svc,
+        "manager": rollcall_manager.manager,
+        "duplicateProxy": duplicateProxy,
+        "incorrectParameter": incorrectParameter,
+        "parameterMissing": parameterMissing,
+        "repeatlyName": repeatlyName,
+        "rollCallNotStarted": rollCallNotStarted,
+    }
+
+
+CHAT_ID = -1001999000401
+ADMIN = {"id": 999, "name": "Admin"}
+BOB = {"id": 200, "name": "Bob", "username": "bob"}
+
+
+class ProxyBase(unittest.IsolatedAsyncioTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        env = _import()
+        cls.proxy = env["proxy_svc"]
+        cls.rc = env["rc_svc"]
+        cls.vote = env["vote_svc"]
+        cls.manager = env["manager"]
+        cls.duplicateProxy = env["duplicateProxy"]
+        cls.incorrectParameter = env["incorrectParameter"]
+        cls.parameterMissing = env["parameterMissing"]
+        cls.repeatlyName = env["repeatlyName"]
+        cls.rollCallNotStarted = env["rollCallNotStarted"]
+
+    def setUp(self):
+        reset_db()
+        self.manager.clear_cache()
+
+    async def _start(self, title="Match"):
+        return await self.rc.start_rollcall(
+            CHAT_ID, title, ADMIN["id"], ADMIN["name"]
+        )
+
+
+class TestSetInFor(ProxyBase):
+
+    async def test_set_in_for_adds_proxy(self):
+        await self._start()
+        result = await self.proxy.set_in_for(
+            CHAT_ID, ADMIN["id"], ADMIN["name"], "Alex"
+        )
+        self.assertEqual(result["action"], "added")
+        self.assertEqual(result["user"]["name"], "Alex")
+        self.assertTrue(result["user"]["is_proxy"])
+        self.assertEqual(result["proxy_owner_id"], ADMIN["id"])
+        in_names = [u["name"] for u in result["rollcall"]["in_list"]]
+        self.assertIn("Alex", in_names)
+
+    async def test_set_in_for_with_comment(self):
+        await self._start()
+        result = await self.proxy.set_in_for(
+            CHAT_ID, ADMIN["id"], ADMIN["name"], "Alex", comment="bringing snacks"
+        )
+        self.assertEqual(result["user"]["comment"], "bringing snacks")
+
+    async def test_set_in_for_duplicate_raises(self):
+        await self._start()
+        await self.proxy.set_in_for(CHAT_ID, ADMIN["id"], ADMIN["name"], "Alex")
+        with self.assertRaises(self.duplicateProxy):
+            await self.proxy.set_in_for(CHAT_ID, ADMIN["id"], ADMIN["name"], "Alex")
+
+    async def test_set_in_for_past_cap_waitlists(self):
+        await self._start()
+        rc = self.manager.get_rollcall(CHAT_ID, 0)
+        rc.inListLimit = 1
+        rc.save()
+        await self.proxy.set_in_for(CHAT_ID, ADMIN["id"], ADMIN["name"], "First")
+        result = await self.proxy.set_in_for(
+            CHAT_ID, ADMIN["id"], ADMIN["name"], "Second"
+        )
+        self.assertEqual(result["action"], "waitlisted")
+        wait_names = [u["name"] for u in result["rollcall"]["wait_list"]]
+        self.assertIn("Second", wait_names)
+
+    async def test_set_in_for_empty_name_raises(self):
+        await self._start()
+        with self.assertRaises(self.parameterMissing):
+            await self.proxy.set_in_for(CHAT_ID, ADMIN["id"], ADMIN["name"], "  ")
+
+    async def test_set_in_for_long_name_raises(self):
+        await self._start()
+        with self.assertRaises(self.parameterMissing):
+            await self.proxy.set_in_for(
+                CHAT_ID, ADMIN["id"], ADMIN["name"], "X" * 60
+            )
+
+    async def test_set_in_for_with_no_active_rollcall(self):
+        with self.assertRaises(self.rollCallNotStarted):
+            await self.proxy.set_in_for(
+                CHAT_ID, ADMIN["id"], ADMIN["name"], "Alex"
+            )
+
+
+class TestSetOutFor(ProxyBase):
+
+    async def test_set_out_for_fresh_adds_to_out(self):
+        await self._start()
+        result = await self.proxy.set_out_for(
+            CHAT_ID, ADMIN["id"], ADMIN["name"], "Alex"
+        )
+        self.assertEqual(result["action"], "added")
+        self.assertFalse(result["was_in"])
+        self.assertIsNone(result["promoted"])
+        out_names = [u["name"] for u in result["rollcall"]["out_list"]]
+        self.assertIn("Alex", out_names)
+
+    async def test_set_out_for_moves_in_proxy(self):
+        await self._start()
+        await self.proxy.set_in_for(CHAT_ID, ADMIN["id"], ADMIN["name"], "Alex")
+        result = await self.proxy.set_out_for(
+            CHAT_ID, ADMIN["id"], ADMIN["name"], "Alex"
+        )
+        self.assertEqual(result["action"], "moved")
+        self.assertTrue(result["was_in"])
+
+    async def test_set_out_for_promotes_waitlister(self):
+        await self._start()
+        rc = self.manager.get_rollcall(CHAT_ID, 0)
+        rc.inListLimit = 1
+        rc.save()
+        await self.proxy.set_in_for(CHAT_ID, ADMIN["id"], ADMIN["name"], "Alex")
+        await self.proxy.set_in_for(CHAT_ID, ADMIN["id"], ADMIN["name"], "Brian")
+        # Brian was waitlisted; now Alex /out should promote Brian
+        result = await self.proxy.set_out_for(
+            CHAT_ID, ADMIN["id"], ADMIN["name"], "Alex"
+        )
+        self.assertEqual(result["action"], "moved")
+        self.assertIsNotNone(result["promoted"])
+        self.assertEqual(result["promoted"]["name"], "Brian")
+        in_names = [u["name"] for u in result["rollcall"]["in_list"]]
+        self.assertIn("Brian", in_names)
+
+
+class TestSetMaybeFor(ProxyBase):
+
+    async def test_set_maybe_for_adds_proxy(self):
+        await self._start()
+        result = await self.proxy.set_maybe_for(
+            CHAT_ID, ADMIN["id"], ADMIN["name"], "Alex"
+        )
+        self.assertEqual(result["action"], "added")
+        maybe_names = [u["name"] for u in result["rollcall"]["maybe_list"]]
+        self.assertIn("Alex", maybe_names)
+
+    async def test_set_maybe_for_promotes_waitlister_after_in(self):
+        await self._start()
+        rc = self.manager.get_rollcall(CHAT_ID, 0)
+        rc.inListLimit = 1
+        rc.save()
+        await self.proxy.set_in_for(CHAT_ID, ADMIN["id"], ADMIN["name"], "Alex")
+        await self.proxy.set_in_for(CHAT_ID, ADMIN["id"], ADMIN["name"], "Brian")
+        result = await self.proxy.set_maybe_for(
+            CHAT_ID, ADMIN["id"], ADMIN["name"], "Alex"
+        )
+        self.assertEqual(result["promoted"]["name"], "Brian")
+
+
+class TestProxyGhostCheck(ProxyBase):
+
+    async def test_check_returns_not_needed_when_tracking_off(self):
+        await self._start()
+        self.manager.set_ghost_tracking_enabled(CHAT_ID, False)
+        result = self.proxy.check_proxy_ghost_reconfirmation_needed(
+            CHAT_ID, "Alex"
+        )
+        self.assertFalse(result["needed"])
+
+    async def test_check_returns_not_needed_for_new_proxy(self):
+        await self._start()
+        result = self.proxy.check_proxy_ghost_reconfirmation_needed(
+            CHAT_ID, "FreshProxy"
+        )
+        self.assertFalse(result["needed"])
+
+    async def test_check_returns_needed_at_limit(self):
+        await self._start()
+        from db import increment_ghost_count
+        # increment_ghost_count accepts a proxy_name kwarg; user_id is
+        # ignored when proxy_name is set (db routes the increment to the
+        # proxy ghost-record).
+        increment_ghost_count(CHAT_ID, 0, "RepeatGhost", proxy_name="RepeatGhost")
+        result = self.proxy.check_proxy_ghost_reconfirmation_needed(
+            CHAT_ID, "RepeatGhost"
+        )
+        self.assertTrue(result["needed"])
+        self.assertEqual(result["ghost_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rollCall/api/main.py
+++ b/rollCall/api/main.py
@@ -27,7 +27,7 @@ from exceptions import (
     rollCallNotStarted,
 )
 from api.rate_limit import rate_limit_middleware
-from api.routes import health, rollcalls, votes
+from api.routes import health, proxy_votes, rollcalls, votes
 from api.schemas.common import ErrorResponse
 
 
@@ -98,6 +98,22 @@ def create_app() -> FastAPI:
     app.include_router(health.router, prefix=API_PREFIX, tags=["health"])
     app.include_router(rollcalls.router, prefix=API_PREFIX, tags=["rollcalls"])
     app.include_router(votes.router, prefix=API_PREFIX, tags=["votes"])
+    app.include_router(proxy_votes.router, prefix=API_PREFIX, tags=["proxy-votes"])
+
+    # Map proxy-specific exceptions to HTTP status codes
+    from exceptions import duplicateProxy, repeatlyName
+    from fastapi import status as _status
+
+    @app.exception_handler(duplicateProxy)
+    @app.exception_handler(repeatlyName)
+    async def _proxy_exception_handler(request, exc):
+        return JSONResponse(
+            status_code=_status.HTTP_409_CONFLICT,
+            content=ErrorResponse(
+                error=type(exc).__name__,
+                detail=str(exc) or type(exc).__name__,
+            ).model_dump(),
+        )
 
     return app
 

--- a/rollCall/api/routes/proxy_votes.py
+++ b/rollCall/api/routes/proxy_votes.py
@@ -1,0 +1,53 @@
+"""
+Proxy-vote route: an admin marks a non-Telegram member as in/out/maybe.
+
+Requires the 'vote' scope (proxy votes are still votes; not a destructive
+action). The `admin_*` fields in the body MUST identify the human
+performing the action — these go into the audit log.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+
+from services import proxy as proxy_svc
+
+from api.auth import AuthedToken, require_scope
+from api.schemas.proxy import ProxyVoteRequest, ProxyVoteResponse
+
+
+router = APIRouter()
+
+
+@router.post(
+    "/chats/{chat_id}/rollcalls/{rc_number}/proxy-votes",
+    response_model=ProxyVoteResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Cast a proxy vote (in/out/maybe) on behalf of a non-Telegram member",
+)
+async def cast_proxy_vote(
+    body: ProxyVoteRequest,
+    chat_id: int = Path(..., description="Telegram chat id"),
+    rc_number: int = Path(..., ge=1, description="1-based rollcall number"),
+    _token: AuthedToken = Depends(require_scope("vote")),
+) -> ProxyVoteResponse:
+    common = dict(
+        chat_id=chat_id,
+        admin_user_id=body.admin_user_id,
+        admin_name=body.admin_name,
+        proxy_name=body.proxy_name,
+        comment=body.comment,
+        rc_number=rc_number - 1,
+    )
+
+    if body.vote == "in":
+        result = await proxy_svc.set_in_for(**common)
+    elif body.vote == "out":
+        result = await proxy_svc.set_out_for(**common)
+    elif body.vote == "maybe":
+        result = await proxy_svc.set_maybe_for(**common)
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown vote choice: {body.vote!r}",
+        )
+
+    return ProxyVoteResponse(**result)

--- a/rollCall/api/schemas/proxy.py
+++ b/rollCall/api/schemas/proxy.py
@@ -1,0 +1,29 @@
+"""Pydantic models for proxy-vote routes."""
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from .common import UserPayload
+from .rollcalls import RollcallResponse
+
+
+class ProxyVoteRequest(BaseModel):
+    vote: Literal["in", "out", "maybe"] = Field(
+        ..., description="Vote choice for the proxy"
+    )
+    proxy_name: str = Field(..., max_length=40)
+    admin_user_id: int = Field(..., description="Telegram user id of the admin acting")
+    admin_name: str = Field(..., description="Display name of the admin")
+    comment: Optional[str] = None
+
+
+class ProxyVoteResponse(BaseModel):
+    action: str = Field(..., description="'added' | 'waitlisted' | 'moved'")
+    rollcall: RollcallResponse
+    user: UserPayload
+    proxy_owner_id: int
+    rc_number_1based: int
+
+    was_in: Optional[bool] = None
+    promoted: Optional[UserPayload] = None

--- a/rollCall/services/__init__.py
+++ b/rollCall/services/__init__.py
@@ -15,6 +15,6 @@ up to the adapter, which decides how to surface them (chat reply, HTTP 4xx,
 etc.).
 """
 
-from . import rollcalls, voting
+from . import proxy, rollcalls, voting
 
-__all__ = ["rollcalls", "voting"]
+__all__ = ["proxy", "rollcalls", "voting"]

--- a/rollCall/services/proxy.py
+++ b/rollCall/services/proxy.py
@@ -1,0 +1,259 @@
+"""
+Proxy voting services — admin votes on behalf of a non-Telegram member.
+
+Mirrors the voting service shape: primitives in, dicts out, same curated
+exceptions, internally serializes via `manager.get_chat_write_lock`.
+
+A proxy user has a string `user_id` (the proxy's name), distinguishing
+them from real Telegram users whose `user_id` is an int. All waitlist /
+promotion semantics are identical to real voting.
+"""
+
+import logging
+from datetime import datetime
+
+from exceptions import (
+    duplicateProxy,
+    parameterMissing,
+    repeatlyName,
+    rollCallNotStarted,
+)
+from models import User
+from rollcall_manager import manager
+from db import (
+    get_ghost_count_by_proxy_name,
+    increment_rollcall_stat,
+    increment_user_stat,
+    log_admin_action,
+)
+
+from .common import resolve_rollcall_or_raise, serialize_rollcall, serialize_user
+
+
+_MAX_PROXY_NAME_LEN = 40
+
+
+def _ts() -> str:
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _rc_db_id(rc) -> int | None:
+    return getattr(rc, "id", None) or getattr(rc, "db_id", None)
+
+
+def _validate_proxy_name(name: str) -> str:
+    name = (name or "").strip()
+    if not name:
+        raise parameterMissing("Proxy name is required")
+    if len(name) > _MAX_PROXY_NAME_LEN:
+        raise parameterMissing(
+            f"Proxy name is too long (max {_MAX_PROXY_NAME_LEN} characters). "
+            f"Got {len(name)}."
+        )
+    return name
+
+
+def check_proxy_ghost_reconfirmation_needed(chat_id: int, proxy_name: str) -> dict:
+    """
+    Mirror of voting.check_ghost_reconfirmation_needed but for proxies.
+    Returns:
+      {"needed": bool, "ghost_count": int, "absent_limit": int, "proxy_name": str}
+    """
+    proxy_name = _validate_proxy_name(proxy_name)
+    if not manager.get_ghost_tracking_enabled(chat_id):
+        return {"needed": False, "ghost_count": 0, "absent_limit": 0, "proxy_name": proxy_name}
+    ghost_count = get_ghost_count_by_proxy_name(chat_id, proxy_name)
+    absent_limit = manager.get_absent_limit(chat_id)
+    return {
+        "needed": ghost_count >= absent_limit and ghost_count > 0,
+        "ghost_count": ghost_count,
+        "absent_limit": absent_limit,
+        "proxy_name": proxy_name,
+    }
+
+
+async def set_in_for(
+    chat_id: int,
+    admin_user_id: int,
+    admin_name: str,
+    proxy_name: str,
+    comment: str | None = None,
+    rc_number: int = 0,
+) -> dict:
+    """
+    Admin adds a proxy user to the IN list. Returns same shape as
+    voting.vote_in plus an `proxy_owner` field for the admin.
+
+    Raises:
+      rollCallNotStarted, incorrectParameter, parameterMissing,
+      duplicateProxy (already in/waiting), repeatlyName (collides
+      with a different proxy already on the lists).
+    """
+    proxy_name = _validate_proxy_name(proxy_name)
+
+    async with manager.get_chat_write_lock(chat_id):
+        rc = resolve_rollcall_or_raise(chat_id, rc_number)
+
+        # Pre-check matches the bot handler: hard-stop if this proxy is
+        # already on IN or WAIT lists (a clearer message than the generic
+        # duplicateProxy raise the addIn path produces).
+        already_present = any(
+            u.name == proxy_name and isinstance(u.user_id, str)
+            for u in rc.inList + rc.waitList
+        )
+        if already_present:
+            raise duplicateProxy(
+                f"'{proxy_name}' is already IN or WAITING for '{rc.title}'."
+            )
+
+        user = User(proxy_name, None, proxy_name, rc.allNames)
+        user.comment = comment or ""
+        rc.set_proxy_owner(user.user_id, admin_user_id)
+
+        result = rc.addIn(user)
+        rc.save()
+
+        log_admin_action(
+            chat_id, admin_user_id, admin_name,
+            "sif", target_name=proxy_name,
+            rollcall_id=getattr(rc, "id", None), details=rc.title,
+        )
+
+        if result == "AB":
+            raise duplicateProxy("No duplicate proxy please :-), Thanks!")
+        if result == "AA":
+            raise repeatlyName("That name already exists!")
+
+        action = "waitlisted" if result == "AC" else "added"
+        return {
+            "action": action,
+            "rollcall": serialize_rollcall(rc, rc_number),
+            "user": serialize_user(user),
+            "proxy_owner_id": admin_user_id,
+            "rc_number_1based": rc_number + 1,
+        }
+
+
+async def set_out_for(
+    chat_id: int,
+    admin_user_id: int,
+    admin_name: str,
+    proxy_name: str,
+    comment: str | None = None,
+    rc_number: int = 0,
+) -> dict:
+    """
+    Admin moves a proxy to the OUT list (or adds them there fresh).
+    If the proxy was previously IN and a waitlister exists, the waitlister
+    is promoted; the promoted user is included in `promoted` so the
+    adapter can announce / DM them.
+
+    Returns the same shape as `voting.vote_out`.
+    """
+    proxy_name = _validate_proxy_name(proxy_name)
+
+    async with manager.get_chat_write_lock(chat_id):
+        rc = resolve_rollcall_or_raise(chat_id, rc_number)
+        user = User(proxy_name, None, proxy_name, rc.allNames)
+        user.comment = comment or ""
+
+        was_in = any(
+            (u.user_id == user.user_id or u.name == user.name) for u in rc.inList
+        )
+
+        result = rc.addOut(user)
+        rc.save()
+
+        log_admin_action(
+            chat_id, admin_user_id, admin_name,
+            "sof", target_name=proxy_name,
+            rollcall_id=getattr(rc, "id", None), details=rc.title,
+        )
+
+        if result == "AB":
+            raise duplicateProxy("No duplicate proxy please :-), Thanks!")
+        if result == "AA":
+            raise repeatlyName("That name already exists!")
+
+        promoted = None
+        action = "added"
+        rc_db_id = _rc_db_id(rc)
+        if isinstance(result, User):
+            promoted = serialize_user(result)
+            action = "moved"
+            if rc_db_id is not None and isinstance(result.user_id, int):
+                # Mirror the same /sof glitch-fix the handler ships: bump
+                # promotion stats for real users moved waitlist→IN.
+                increment_user_stat(chat_id, result.user_id, "total_waiting_to_in")
+                increment_user_stat(chat_id, result.user_id, "total_in")
+                increment_rollcall_stat(rc_db_id, "total_in")
+        elif was_in:
+            action = "moved"
+
+        return {
+            "action": action,
+            "was_in": was_in,
+            "promoted": promoted,
+            "rollcall": serialize_rollcall(rc, rc_number),
+            "user": serialize_user(user),
+            "proxy_owner_id": admin_user_id,
+            "rc_number_1based": rc_number + 1,
+        }
+
+
+async def set_maybe_for(
+    chat_id: int,
+    admin_user_id: int,
+    admin_name: str,
+    proxy_name: str,
+    comment: str | None = None,
+    rc_number: int = 0,
+) -> dict:
+    """Admin moves a proxy to MAYBE. Same promotion semantics as set_out_for."""
+    proxy_name = _validate_proxy_name(proxy_name)
+
+    async with manager.get_chat_write_lock(chat_id):
+        rc = resolve_rollcall_or_raise(chat_id, rc_number)
+        user = User(proxy_name, None, proxy_name, rc.allNames)
+        user.comment = comment or ""
+
+        was_in = any(
+            (u.user_id == user.user_id or u.name == user.name) for u in rc.inList
+        )
+
+        result = rc.addMaybe(user)
+        rc.save()
+
+        log_admin_action(
+            chat_id, admin_user_id, admin_name,
+            "smf", target_name=proxy_name,
+            rollcall_id=getattr(rc, "id", None), details=rc.title,
+        )
+
+        if result == "AB":
+            raise duplicateProxy("No duplicate proxy please :-), Thanks!")
+        if result == "AA":
+            raise repeatlyName("That name already exists!")
+
+        promoted = None
+        action = "added"
+        rc_db_id = _rc_db_id(rc)
+        if isinstance(result, User):
+            promoted = serialize_user(result)
+            action = "moved"
+            if rc_db_id is not None and isinstance(result.user_id, int):
+                increment_user_stat(chat_id, result.user_id, "total_waiting_to_in")
+                increment_user_stat(chat_id, result.user_id, "total_in")
+                increment_rollcall_stat(rc_db_id, "total_in")
+        elif was_in:
+            action = "moved"
+
+        return {
+            "action": action,
+            "was_in": was_in,
+            "promoted": promoted,
+            "rollcall": serialize_rollcall(rc, rc_number),
+            "user": serialize_user(user),
+            "proxy_owner_id": admin_user_id,
+            "rc_number_1based": rc_number + 1,
+        }


### PR DESCRIPTION
Slice 4a of the REST API plan — proxy voting (set_in_for / sof / smf) extracted into the service layer and exposed via REST. Bot unchanged.

## What's in this PR

\`\`\`
rollCall/services/proxy.py      set_in_for, set_out_for, set_maybe_for,
                                check_proxy_ghost_reconfirmation_needed
rollCall/api/schemas/proxy.py   ProxyVoteRequest, ProxyVoteResponse
rollCall/api/routes/proxy_votes.py  POST /chats/{id}/rollcalls/{n}/proxy-votes
rollCall/api/main.py            register route + map duplicateProxy/repeatlyName → 409
integration_tests/test_services_proxy.py  (+15 tests)
integration_tests/test_api_proxy_votes.py (+8 tests)
\`\`\`

## Route

\`POST /api/v1/chats/{chat_id}/rollcalls/{rc_number}/proxy-votes\`  
Requires \`vote\` scope. Body: \`{vote: in|out|maybe, proxy_name, admin_user_id, admin_name, comment?}\`

Status codes: 201 success · 409 duplicate/repeatlyName · 422 validation · 403 wrong scope

## Test plan

- [x] smoke 9/9
- [x] unit 298/298
- [x] integration **491/491** (+23)
- [x] functional 121/121
- [x] persistence 44/44 → **963 total**
- [ ] CI green

## Next: PR 4b — templates + schedules services + routes