### PR TITLE
feat: templates + schedules service layer + REST routes (slice 4b)

### DIFF
--- a/integration_tests/test_api_templates.py
+++ b/integration_tests/test_api_templates.py
@@ -1,0 +1,194 @@
+"""
+Integration tests for template + schedule REST routes.
+FastAPI TestClient, real DB, scoped tokens.
+"""
+import unittest
+
+from fastapi.testclient import TestClient
+
+from mock_helpers import reset_db
+
+
+def _import():
+    import bot_state  # noqa
+    import rollcall_manager
+    from api.main import app
+    return {"app": app, "manager": rollcall_manager.manager}
+
+
+CHAT_ID = -1001999000101
+ADMIN = {"id": 999, "name": "Admin"}
+
+
+class TemplateAPIBase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        env = _import()
+        cls.app = env["app"]
+        cls.manager = env["manager"]
+        cls.client = TestClient(cls.app)
+
+    def setUp(self):
+        reset_db()
+        self.manager.clear_cache()
+        from api.rate_limit import reset_buckets_for_tests
+        reset_buckets_for_tests()
+        from db import _hash_token, generate_api_token, insert_api_token
+        token = generate_api_token()
+        insert_api_token(_hash_token(token), CHAT_ID, "read,vote,admin",
+                         label="test", issued_by_user_id=ADMIN["id"])
+        self.client.headers["Authorization"] = f"Bearer {token}"
+
+    def _upsert(self, name, **kwargs):
+        body = {"admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"], **kwargs}
+        return self.client.put(f"/api/v1/chats/{CHAT_ID}/templates/{name}", json=body)
+
+    def _start(self, name, extra=None):
+        body = {"admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"]}
+        if extra:
+            body["extra_title"] = extra
+        return self.client.post(f"/api/v1/chats/{CHAT_ID}/templates/{name}/start", json=body)
+
+    def _admin_body(self):
+        return {"admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"]}
+
+
+class TestTemplateCRUD(TemplateAPIBase):
+
+    def test_list_empty(self):
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/templates")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), [])
+
+    def test_upsert_creates_template(self):
+        r = self._upsert("friday", title="Friday FC", limit=14, location="Field A")
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["name"], "friday")
+        self.assertEqual(body["title"], "Friday FC")
+        self.assertEqual(body["limit"], 14)
+
+    def test_list_returns_created(self):
+        self._upsert("friday", title="Fri")
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/templates")
+        self.assertEqual(r.status_code, 200)
+        names = [t["name"] for t in r.json()]
+        self.assertIn("friday", names)
+
+    def test_get_single_template(self):
+        self._upsert("friday", title="Fri")
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/templates/friday")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["title"], "Fri")
+
+    def test_get_nonexistent_returns_422(self):
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/templates/ghost")
+        self.assertEqual(r.status_code, 422)
+
+    def test_upsert_partial_update_preserves_fields(self):
+        self._upsert("friday", title="Fri", limit=10)
+        r = self._upsert("friday", title="Friday FC")  # don't pass limit
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["limit"], 10)
+
+    def test_delete_template(self):
+        self._upsert("friday", title="Fri")
+        r = self.client.request("DELETE", f"/api/v1/chats/{CHAT_ID}/templates/friday",
+                                json=self._admin_body())
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.json()["deleted"])
+
+    def test_delete_nonexistent_returns_422(self):
+        r = self.client.request("DELETE", f"/api/v1/chats/{CHAT_ID}/templates/ghost",
+                                json=self._admin_body())
+        self.assertEqual(r.status_code, 422)
+
+
+class TestStartTemplate(TemplateAPIBase):
+
+    def test_start_creates_rollcall(self):
+        self._upsert("friday", title="Friday FC", limit=10)
+        r = self._start("friday")
+        self.assertEqual(r.status_code, 201)
+        body = r.json()
+        self.assertEqual(body["title"], "Friday FC")
+
+    def test_start_with_extra_title(self):
+        self._upsert("friday", title="Friday")
+        r = self._start("friday", extra="With Guests")
+        self.assertEqual(r.status_code, 201)
+        self.assertIn("With Guests", r.json()["title"])
+
+    def test_start_nonexistent_returns_422(self):
+        r = self._start("ghost")
+        self.assertEqual(r.status_code, 422)
+
+    def test_start_requires_admin_scope(self):
+        from db import _hash_token, generate_api_token, insert_api_token
+        ro = generate_api_token()
+        insert_api_token(_hash_token(ro), CHAT_ID, "read", label="ro",
+                         issued_by_user_id=ADMIN["id"])
+        self._upsert("friday", title="F")
+        r = self.client.post(f"/api/v1/chats/{CHAT_ID}/templates/friday/start",
+                             json=self._admin_body(),
+                             headers={"Authorization": f"Bearer {ro}"})
+        self.assertEqual(r.status_code, 403)
+
+
+class TestScheduleRoutes(TemplateAPIBase):
+
+    def setUp(self):
+        super().setUp()
+        self._upsert("friday", title="F", event_day="friday", event_time="18:00")
+
+    def _sched_body(self, **kwargs):
+        return {"admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"], **kwargs}
+
+    def test_get_schedule_returns_disabled_by_default(self):
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/templates/friday/schedule")
+        self.assertEqual(r.status_code, 200)
+        self.assertFalse(r.json()["schedule_enabled"])
+
+    def test_set_weekly_schedule(self):
+        r = self.client.put(
+            f"/api/v1/chats/{CHAT_ID}/templates/friday/schedule",
+            json=self._sched_body(recurrence_type="weekly",
+                                  schedule_day="friday", schedule_time="18:00")
+        )
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertTrue(body["schedule_enabled"])
+        self.assertEqual(body["schedule_day"], "friday")
+
+    def test_set_monthly_schedule(self):
+        r = self.client.put(
+            f"/api/v1/chats/{CHAT_ID}/templates/friday/schedule",
+            json=self._sched_body(recurrence_type="monthly",
+                                  monthly_day=15, schedule_time="09:00")
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["recurrence_type"], "monthly")
+
+    def test_disable_schedule(self):
+        self.client.put(
+            f"/api/v1/chats/{CHAT_ID}/templates/friday/schedule",
+            json=self._sched_body(schedule_day="friday", schedule_time="18:00")
+        )
+        r = self.client.request(
+            "DELETE", f"/api/v1/chats/{CHAT_ID}/templates/friday/schedule",
+            json=self._admin_body()
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertFalse(r.json()["schedule_enabled"])
+
+    def test_set_schedule_bad_day_returns_422(self):
+        r = self.client.put(
+            f"/api/v1/chats/{CHAT_ID}/templates/friday/schedule",
+            json=self._sched_body(schedule_day="fri", schedule_time="18:00")
+        )
+        self.assertEqual(r.status_code, 422)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integration_tests/test_services_templates.py
+++ b/integration_tests/test_services_templates.py
@@ -1,0 +1,206 @@
+"""
+Tests for services/templates.py — upsert, list, get, start, delete,
+get/set/disable schedule.
+"""
+import unittest
+
+from mock_helpers import reset_db
+
+
+def _import():
+    import bot_state  # noqa
+    import rollcall_manager
+    from services import templates as tmpl_svc
+    from services import rollcalls as rc_svc
+    from exceptions import amountOfRollCallsReached, incorrectParameter, parameterMissing
+    return {
+        "tmpl": tmpl_svc,
+        "rc": rc_svc,
+        "manager": rollcall_manager.manager,
+        "incorrectParameter": incorrectParameter,
+        "parameterMissing": parameterMissing,
+        "amountOfRollCallsReached": amountOfRollCallsReached,
+    }
+
+
+CHAT_ID = -1001999000201
+ADMIN = {"id": 999, "name": "Admin"}
+
+
+class TemplateBase(unittest.IsolatedAsyncioTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        env = _import()
+        cls.tmpl = env["tmpl"]
+        cls.rc = env["rc"]
+        cls.manager = env["manager"]
+        cls.incorrectParameter = env["incorrectParameter"]
+        cls.parameterMissing = env["parameterMissing"]
+        cls.amountOfRollCallsReached = env["amountOfRollCallsReached"]
+
+    def setUp(self):
+        reset_db()
+        self.manager.clear_cache()
+
+
+class TestUpsertAndList(TemplateBase):
+
+    def test_upsert_creates_template(self):
+        t = self.tmpl.upsert_template(
+            CHAT_ID, "friday", ADMIN["id"], ADMIN["name"],
+            title="Friday Football", limit=14, location="Field A"
+        )
+        self.assertEqual(t["name"], "friday")
+        self.assertEqual(t["title"], "Friday Football")
+        self.assertEqual(t["limit"], 14)
+        self.assertEqual(t["location"], "Field A")
+
+    def test_list_returns_all_templates(self):
+        self.tmpl.upsert_template(CHAT_ID, "monday", ADMIN["id"], ADMIN["name"], title="Mon")
+        self.tmpl.upsert_template(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"], title="Fri")
+        listed = self.tmpl.list_templates(CHAT_ID)
+        names = [t["name"] for t in listed]
+        self.assertIn("monday", names)
+        self.assertIn("friday", names)
+
+    def test_list_empty_chat(self):
+        self.assertEqual(self.tmpl.list_templates(CHAT_ID), [])
+
+    def test_upsert_updates_existing_preserving_unspecified_fields(self):
+        self.tmpl.upsert_template(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"],
+                                  title="Friday Football", limit=14)
+        # Update only the title — limit should be preserved
+        t = self.tmpl.upsert_template(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"],
+                                      title="Friday FC")
+        self.assertEqual(t["title"], "Friday FC")
+        self.assertEqual(t["limit"], 14)
+
+    def test_upsert_invalid_event_day_raises(self):
+        with self.assertRaises(self.incorrectParameter):
+            self.tmpl.upsert_template(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"],
+                                      event_day="fri")  # abbreviation not valid
+
+    def test_upsert_empty_name_raises(self):
+        with self.assertRaises(self.parameterMissing):
+            self.tmpl.upsert_template(CHAT_ID, "  ", ADMIN["id"], ADMIN["name"])
+
+
+class TestGetAndDelete(TemplateBase):
+
+    def test_get_existing_template(self):
+        self.tmpl.upsert_template(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"], title="Fri")
+        t = self.tmpl.get_one_template(CHAT_ID, "friday")
+        self.assertEqual(t["title"], "Fri")
+
+    def test_get_nonexistent_raises(self):
+        with self.assertRaises(self.incorrectParameter):
+            self.tmpl.get_one_template(CHAT_ID, "ghost")
+
+    def test_delete_removes_template(self):
+        self.tmpl.upsert_template(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"])
+        result = self.tmpl.delete_one_template(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"])
+        self.assertTrue(result["deleted"])
+        self.assertEqual(self.tmpl.list_templates(CHAT_ID), [])
+
+    def test_delete_nonexistent_raises(self):
+        with self.assertRaises(self.incorrectParameter):
+            self.tmpl.delete_one_template(CHAT_ID, "ghost", ADMIN["id"], ADMIN["name"])
+
+
+class TestStartTemplate(TemplateBase):
+
+    async def test_start_creates_rollcall(self):
+        self.tmpl.upsert_template(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"],
+                                  title="Friday FC", limit=10)
+        rc = await self.tmpl.start_template(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"])
+        self.assertEqual(rc["title"], "Friday FC")
+        active = self.manager.get_rollcalls(CHAT_ID)
+        self.assertEqual(len(active), 1)
+
+    async def test_start_with_extra_title(self):
+        self.tmpl.upsert_template(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"], title="Friday")
+        rc = await self.tmpl.start_template(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"],
+                                            extra_title="With Guests")
+        self.assertIn("With Guests", rc["title"])
+
+    async def test_start_nonexistent_template_raises(self):
+        with self.assertRaises(self.incorrectParameter):
+            await self.tmpl.start_template(CHAT_ID, "ghost", ADMIN["id"], ADMIN["name"])
+
+    async def test_start_raises_at_rollcall_cap(self):
+        self.tmpl.upsert_template(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"], title="F")
+        for _ in range(3):
+            await self.rc.start_rollcall(CHAT_ID, "X", ADMIN["id"], ADMIN["name"])
+        with self.assertRaises(self.amountOfRollCallsReached):
+            await self.tmpl.start_template(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"])
+
+
+class TestSchedule(TemplateBase):
+
+    def setUp(self):
+        super().setUp()
+        # All schedule tests need event_day + event_time on the template
+        self.tmpl.upsert_template(
+            CHAT_ID, "friday", ADMIN["id"], ADMIN["name"],
+            title="Friday FC", event_day="friday", event_time="18:00"
+        )
+
+    def test_set_weekly_schedule(self):
+        result = self.tmpl.set_schedule(
+            CHAT_ID, "friday", ADMIN["id"], ADMIN["name"],
+            recurrence_type="weekly", schedule_day="friday", schedule_time="18:00"
+        )
+        self.assertTrue(result["schedule_enabled"])
+        self.assertEqual(result["schedule_day"], "friday")
+        self.assertEqual(result["schedule_time"], "18:00")
+        self.assertEqual(result["recurrence_type"], "weekly")
+
+    def test_set_biweekly_schedule(self):
+        result = self.tmpl.set_schedule(
+            CHAT_ID, "friday", ADMIN["id"], ADMIN["name"],
+            recurrence_type="biweekly", schedule_day="friday", schedule_time="18:00"
+        )
+        self.assertEqual(result["recurrence_type"], "biweekly")
+
+    def test_set_monthly_schedule(self):
+        result = self.tmpl.set_schedule(
+            CHAT_ID, "friday", ADMIN["id"], ADMIN["name"],
+            recurrence_type="monthly", monthly_day=15, schedule_time="09:00"
+        )
+        self.assertEqual(result["recurrence_type"], "monthly")
+
+    def test_disable_schedule(self):
+        self.tmpl.set_schedule(
+            CHAT_ID, "friday", ADMIN["id"], ADMIN["name"],
+            schedule_day="friday", schedule_time="18:00"
+        )
+        result = self.tmpl.disable_schedule(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"])
+        self.assertFalse(result["schedule_enabled"])
+
+    def test_enable_schedule(self):
+        self.tmpl.set_schedule(
+            CHAT_ID, "friday", ADMIN["id"], ADMIN["name"],
+            schedule_day="friday", schedule_time="18:00"
+        )
+        self.tmpl.disable_schedule(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"])
+        result = self.tmpl.enable_schedule(CHAT_ID, "friday", ADMIN["id"], ADMIN["name"])
+        self.assertTrue(result["schedule_enabled"])
+
+    def test_set_schedule_bad_weekday_raises(self):
+        with self.assertRaises(self.incorrectParameter):
+            self.tmpl.set_schedule(
+                CHAT_ID, "friday", ADMIN["id"], ADMIN["name"],
+                schedule_day="fri", schedule_time="18:00"
+            )
+
+    def test_set_schedule_bad_time_raises(self):
+        with self.assertRaises(self.incorrectParameter):
+            self.tmpl.set_schedule(
+                CHAT_ID, "friday", ADMIN["id"], ADMIN["name"],
+                schedule_day="friday", schedule_time="25:99"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rollCall/api/main.py
+++ b/rollCall/api/main.py
@@ -27,7 +27,7 @@ from exceptions import (
     rollCallNotStarted,
 )
 from api.rate_limit import rate_limit_middleware
-from api.routes import health, proxy_votes, rollcalls, votes
+from api.routes import health, proxy_votes, rollcalls, templates, votes
 from api.schemas.common import ErrorResponse
 
 
@@ -99,6 +99,7 @@ def create_app() -> FastAPI:
     app.include_router(rollcalls.router, prefix=API_PREFIX, tags=["rollcalls"])
     app.include_router(votes.router, prefix=API_PREFIX, tags=["votes"])
     app.include_router(proxy_votes.router, prefix=API_PREFIX, tags=["proxy-votes"])
+    app.include_router(templates.router, prefix=API_PREFIX, tags=["templates"])
 
     # Map proxy-specific exceptions to HTTP status codes
     from exceptions import duplicateProxy, repeatlyName

--- a/rollCall/api/routes/templates.py
+++ b/rollCall/api/routes/templates.py
@@ -1,0 +1,183 @@
+"""
+Template + schedule routes.
+
+All mutations require the 'admin' scope (templates drive rollcall creation
+and scheduling, which is admin-only in the bot). Read access requires 'read'.
+"""
+
+from typing import List
+
+from fastapi import APIRouter, Depends, Path, status
+
+from services import templates as tmpl_svc
+
+from api.auth import AuthedToken, require_scope
+from api.schemas.rollcalls import RollcallResponse
+from api.schemas.templates import (
+    DeleteTemplateResponse,
+    ScheduleResponse,
+    SetScheduleRequest,
+    StartTemplateRequest,
+    TemplateResponse,
+    ToggleScheduleRequest,
+    UpsertTemplateRequest,
+)
+
+
+router = APIRouter()
+
+
+@router.get(
+    "/chats/{chat_id}/templates",
+    response_model=List[TemplateResponse],
+    summary="List all templates for a chat",
+)
+async def list_templates(
+    chat_id: int = Path(...),
+    _token: AuthedToken = Depends(require_scope("read")),
+) -> List[TemplateResponse]:
+    return [TemplateResponse(**t) for t in tmpl_svc.list_templates(chat_id)]
+
+
+@router.get(
+    "/chats/{chat_id}/templates/{name}",
+    response_model=TemplateResponse,
+    summary="Get a single template by name",
+)
+async def get_template(
+    chat_id: int = Path(...),
+    name: str = Path(...),
+    _token: AuthedToken = Depends(require_scope("read")),
+) -> TemplateResponse:
+    return TemplateResponse(**tmpl_svc.get_one_template(chat_id, name))
+
+
+@router.put(
+    "/chats/{chat_id}/templates/{name}",
+    response_model=TemplateResponse,
+    summary="Create or update a template (partial update supported)",
+)
+async def upsert_template(
+    body: UpsertTemplateRequest,
+    chat_id: int = Path(...),
+    name: str = Path(...),
+    _token: AuthedToken = Depends(require_scope("admin")),
+) -> TemplateResponse:
+    result = tmpl_svc.upsert_template(
+        chat_id=chat_id,
+        name=name,
+        admin_user_id=body.admin_user_id,
+        admin_name=body.admin_name,
+        title=body.title,
+        limit=body.limit,
+        location=body.location,
+        fee=body.fee,
+        offset_days=body.offset_days,
+        offset_hours=body.offset_hours,
+        offset_minutes=body.offset_minutes,
+        event_day=body.event_day,
+        event_time=body.event_time,
+    )
+    return TemplateResponse(**result)
+
+
+@router.post(
+    "/chats/{chat_id}/templates/{name}/start",
+    response_model=RollcallResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Start a rollcall from a template",
+)
+async def start_template(
+    body: StartTemplateRequest,
+    chat_id: int = Path(...),
+    name: str = Path(...),
+    _token: AuthedToken = Depends(require_scope("admin")),
+) -> RollcallResponse:
+    result = await tmpl_svc.start_template(
+        chat_id=chat_id,
+        name=name,
+        admin_user_id=body.admin_user_id,
+        admin_name=body.admin_name,
+        extra_title=body.extra_title,
+    )
+    return RollcallResponse(**result)
+
+
+@router.delete(
+    "/chats/{chat_id}/templates/{name}",
+    response_model=DeleteTemplateResponse,
+    summary="Delete a template",
+)
+async def delete_template(
+    body: ToggleScheduleRequest,
+    chat_id: int = Path(...),
+    name: str = Path(...),
+    _token: AuthedToken = Depends(require_scope("admin")),
+) -> DeleteTemplateResponse:
+    return DeleteTemplateResponse(
+        **tmpl_svc.delete_one_template(
+            chat_id=chat_id,
+            name=name,
+            admin_user_id=body.admin_user_id,
+            admin_name=body.admin_name,
+        )
+    )
+
+
+@router.get(
+    "/chats/{chat_id}/templates/{name}/schedule",
+    response_model=ScheduleResponse,
+    summary="Get schedule info for a template",
+)
+async def get_schedule(
+    chat_id: int = Path(...),
+    name: str = Path(...),
+    _token: AuthedToken = Depends(require_scope("read")),
+) -> ScheduleResponse:
+    return ScheduleResponse(**tmpl_svc.get_schedule(chat_id, name))
+
+
+@router.put(
+    "/chats/{chat_id}/templates/{name}/schedule",
+    response_model=ScheduleResponse,
+    summary="Set or update the auto-start schedule for a template",
+)
+async def set_schedule(
+    body: SetScheduleRequest,
+    chat_id: int = Path(...),
+    name: str = Path(...),
+    _token: AuthedToken = Depends(require_scope("admin")),
+) -> ScheduleResponse:
+    return ScheduleResponse(
+        **tmpl_svc.set_schedule(
+            chat_id=chat_id,
+            name=name,
+            admin_user_id=body.admin_user_id,
+            admin_name=body.admin_name,
+            recurrence_type=body.recurrence_type,
+            schedule_day=body.schedule_day,
+            schedule_time=body.schedule_time,
+            monthly_day=body.monthly_day,
+        )
+    )
+
+
+@router.delete(
+    "/chats/{chat_id}/templates/{name}/schedule",
+    response_model=ScheduleResponse,
+    summary="Disable the auto-start schedule for a template",
+)
+async def disable_schedule(
+    body: ToggleScheduleRequest,
+    chat_id: int = Path(...),
+    name: str = Path(...),
+    _token: AuthedToken = Depends(require_scope("admin")),
+) -> ScheduleResponse:
+    return ScheduleResponse(
+        **tmpl_svc.disable_schedule(
+            chat_id=chat_id,
+            name=name,
+            admin_user_id=body.admin_user_id,
+            admin_name=body.admin_name,
+        )
+    )

--- a/rollCall/api/schemas/templates.py
+++ b/rollCall/api/schemas/templates.py
@@ -1,0 +1,92 @@
+"""Pydantic models for template + schedule routes."""
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from .rollcalls import RollcallResponse
+
+
+class TemplateResponse(BaseModel):
+    name: str
+    title: Optional[str] = None
+    limit: Optional[int] = None
+    location: Optional[str] = None
+    fee: Optional[str] = None
+    offset_days: Optional[int] = None
+    offset_hours: Optional[int] = None
+    offset_minutes: Optional[int] = None
+    event_day: Optional[str] = None
+    event_time: Optional[str] = None
+    schedule_day: Optional[str] = None
+    schedule_time: Optional[str] = None
+    schedule_enabled: bool = False
+    recurrence_type: str = "weekly"
+    last_scheduled_date: Optional[str] = None
+
+
+class UpsertTemplateRequest(BaseModel):
+    admin_user_id: int
+    admin_name: str
+    title: Optional[str] = None
+    limit: Optional[int] = None
+    location: Optional[str] = None
+    fee: Optional[str] = None
+    offset_days: Optional[int] = None
+    offset_hours: Optional[int] = None
+    offset_minutes: Optional[int] = None
+    event_day: Optional[str] = Field(
+        None,
+        description="Full weekday name (e.g. 'friday') for auto-close"
+    )
+    event_time: Optional[str] = Field(
+        None,
+        description="HH:MM for auto-close time"
+    )
+
+
+class StartTemplateRequest(BaseModel):
+    admin_user_id: int
+    admin_name: str
+    extra_title: Optional[str] = Field(
+        None,
+        description="Optional suffix appended to the template's base title"
+    )
+
+
+class DeleteTemplateResponse(BaseModel):
+    name: str
+    deleted: bool
+
+
+class ScheduleResponse(BaseModel):
+    name: str
+    schedule_day: Optional[str] = None
+    schedule_time: Optional[str] = None
+    schedule_enabled: bool = False
+    recurrence_type: str = "weekly"
+    last_scheduled_date: Optional[str] = None
+
+
+class SetScheduleRequest(BaseModel):
+    admin_user_id: int
+    admin_name: str
+    recurrence_type: Literal["weekly", "biweekly", "monthly"] = "weekly"
+    schedule_day: Optional[str] = Field(
+        None,
+        description="Full weekday name for weekly/biweekly. Required unless recurrence_type=monthly."
+    )
+    schedule_time: Optional[str] = Field(
+        None,
+        description="HH:MM. Required."
+    )
+    monthly_day: Optional[int] = Field(
+        None,
+        ge=1, le=31,
+        description="Day of month (1-31). Required when recurrence_type=monthly."
+    )
+
+
+class ToggleScheduleRequest(BaseModel):
+    admin_user_id: int
+    admin_name: str

--- a/rollCall/services/__init__.py
+++ b/rollCall/services/__init__.py
@@ -15,6 +15,6 @@ up to the adapter, which decides how to surface them (chat reply, HTTP 4xx,
 etc.).
 """
 
-from . import proxy, rollcalls, voting
+from . import proxy, rollcalls, templates, voting
 
-__all__ = ["proxy", "rollcalls", "voting"]
+__all__ = ["proxy", "rollcalls", "templates", "voting"]

--- a/rollCall/services/templates.py
+++ b/rollCall/services/templates.py
@@ -1,0 +1,395 @@
+"""
+Template services — list, upsert, start (spawn rollcall), delete,
+get_schedule, set_schedule, disable_schedule, enable_schedule.
+
+Framework-agnostic: primitives in, dicts out, curated exceptions only.
+"""
+import logging
+from datetime import datetime, timedelta
+from typing import Optional
+
+import pytz
+
+from exceptions import (
+    amountOfRollCallsReached,
+    incorrectParameter,
+    parameterMissing,
+)
+from functions import WEEKDAY_MAP, get_next_weekday_datetime
+from rollcall_manager import manager
+from db import (
+    create_or_update_template,
+    delete_template,
+    disable_template_schedule,
+    enable_template_schedule,
+    get_template,
+    get_templates,
+    log_admin_action,
+    set_template_schedule,
+)
+
+from .common import MAX_ROLLCALLS_PER_CHAT, serialize_rollcall
+
+
+def _ts() -> str:
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+# ─── Serialization ────────────────────────────────────────────────────────────
+
+def _serialize_template(t: dict) -> dict:
+    """Normalize a DB template row into a consistent dict."""
+    return {
+        "name": t.get("name"),
+        "title": t.get("title"),
+        "limit": t.get("inlistlimit"),
+        "location": t.get("location"),
+        "fee": t.get("eventfee"),
+        "offset_days": t.get("offsetdays"),
+        "offset_hours": t.get("offsethours"),
+        "offset_minutes": t.get("offsetminutes"),
+        "event_day": t.get("event_day"),
+        "event_time": t.get("event_time"),
+        "schedule_day": t.get("schedule_day"),
+        "schedule_time": t.get("schedule_time"),
+        # schedule_enabled is stored as 1/"1"/True or 0/"0"/False/None
+        # depending on DB type and migration path; normalize explicitly.
+        "schedule_enabled": str(t.get("schedule_enabled", "0")) not in ("0", "False", "None", ""),
+        "recurrence_type": t.get("recurrence_type") or "weekly",
+        "last_scheduled_date": t.get("last_scheduled_date"),
+    }
+
+
+# ─── List / get ───────────────────────────────────────────────────────────────
+
+def list_templates(chat_id: int) -> list[dict]:
+    """Return all templates for a chat."""
+    return [_serialize_template(t) for t in get_templates(chat_id)]
+
+
+def get_one_template(chat_id: int, name: str) -> dict:
+    """
+    Return a single template by name.
+    Raises:
+      parameterMissing — name is empty
+      incorrectParameter — template not found
+    """
+    name = _validate_name(name)
+    t = get_template(chat_id, name)
+    if not t:
+        raise incorrectParameter(f"Template '{name}' not found. Use /templates to list.")
+    return _serialize_template(t)
+
+
+# ─── Upsert ───────────────────────────────────────────────────────────────────
+
+def _validate_name(name: str) -> str:
+    n = (name or "").strip()
+    if not n:
+        raise parameterMissing("Template name is required")
+    return n
+
+
+def upsert_template(
+    chat_id: int,
+    name: str,
+    admin_user_id: int,
+    admin_name: str,
+    title: Optional[str] = None,
+    limit: Optional[int] = None,
+    location: Optional[str] = None,
+    fee: Optional[str] = None,
+    offset_days: Optional[int] = None,
+    offset_hours: Optional[int] = None,
+    offset_minutes: Optional[int] = None,
+    event_day: Optional[str] = None,
+    event_time: Optional[str] = None,
+) -> dict:
+    """
+    Create or update a template. Partial updates merge with the existing
+    row — fields passed as None are preserved from the existing template
+    (matching the bot handler's behaviour).
+
+    Returns the full serialized template after save.
+    Raises:
+      parameterMissing — name empty
+      incorrectParameter — event_day is not a valid weekday name
+    """
+    name = _validate_name(name)
+    if event_day is not None and event_day.lower() not in WEEKDAY_MAP:
+        raise incorrectParameter(
+            f"'{event_day}' is not a valid weekday. "
+            "Use: monday, tuesday, wednesday, thursday, friday, saturday, sunday"
+        )
+
+    # Merge with existing row so callers can do partial updates
+    existing = get_template(chat_id, name) or {}
+    merged = {
+        "title":          title if title is not None else existing.get("title"),
+        "inlistlimit":    limit if limit is not None else existing.get("inlistlimit"),
+        "location":       location if location is not None else existing.get("location"),
+        "eventfee":       fee if fee is not None else existing.get("eventfee"),
+        "offsetdays":     offset_days if offset_days is not None else existing.get("offsetdays"),
+        "offsethours":    offset_hours if offset_hours is not None else existing.get("offsethours"),
+        "offsetminutes":  offset_minutes if offset_minutes is not None else existing.get("offsetminutes"),
+        "event_day":      event_day if event_day is not None else existing.get("event_day"),
+        "event_time":     event_time if event_time is not None else existing.get("event_time"),
+    }
+
+    ok = create_or_update_template(chat_id, name, **merged)
+    if not ok:
+        raise incorrectParameter("Failed to save template. Please try again.")
+
+    log_admin_action(
+        chat_id, admin_user_id, admin_name,
+        "set_template", target_name=name,
+    )
+    return _serialize_template({"name": name, **merged,
+                                "schedule_day": existing.get("schedule_day"),
+                                "schedule_time": existing.get("schedule_time"),
+                                "schedule_enabled": existing.get("schedule_enabled"),
+                                "recurrence_type": existing.get("recurrence_type"),
+                                "last_scheduled_date": existing.get("last_scheduled_date")})
+
+
+# ─── Start (spawn rollcall from template) ─────────────────────────────────────
+
+async def start_template(
+    chat_id: int,
+    name: str,
+    admin_user_id: int,
+    admin_name: str,
+    extra_title: Optional[str] = None,
+) -> dict:
+    """
+    Create a new active rollcall from the template's settings.
+
+    Returns the serialized rollcall that was created.
+    Raises:
+      parameterMissing — name empty
+      incorrectParameter — template not found
+      amountOfRollCallsReached — already at 3 active rollcalls
+    """
+    name = _validate_name(name)
+    tmpl = get_template(chat_id, name)
+    if not tmpl:
+        raise incorrectParameter(f"Template '{name}' not found.")
+
+    rollcalls = manager.get_rollcalls(chat_id)
+    if len(rollcalls) >= MAX_ROLLCALLS_PER_CHAT:
+        raise amountOfRollCallsReached(
+            f"Allowed Maximum number of active roll calls per group is {MAX_ROLLCALLS_PER_CHAT}."
+        )
+
+    base_title = tmpl.get("title") or ""
+    if extra_title:
+        title = (base_title + " – " + extra_title).strip(" –")
+    else:
+        title = base_title or name
+
+    rc = manager.add_rollcall(chat_id, title)
+
+    if tmpl.get("inlistlimit") is not None:
+        rc.inListLimit = tmpl["inlistlimit"]
+    if tmpl.get("location"):
+        rc.location = tmpl["location"]
+    if tmpl.get("eventfee"):
+        rc.event_fee = tmpl["eventfee"]
+
+    chat = manager.get_chat(chat_id)
+    tzname = chat.get("timezone", "Asia/Kolkata")
+    try:
+        tz = pytz.timezone(tzname)
+    except Exception:
+        tz = pytz.timezone("Asia/Kolkata")
+        tzname = "Asia/Kolkata"
+    rc.timezone = tzname
+    rc.finalizeDate = None
+
+    event_day = tmpl.get("event_day")
+    event_time = tmpl.get("event_time")
+    if event_day and event_time:
+        dt = get_next_weekday_datetime(tz, event_day, event_time)
+        if dt:
+            rc.finalizeDate = dt
+
+    if rc.finalizeDate is None:
+        days = tmpl.get("offsetdays")
+        hours = tmpl.get("offsethours")
+        minutes = tmpl.get("offsetminutes")
+        if any(v is not None for v in (days, hours, minutes)):
+            now = datetime.now(tz)
+            rc.finalizeDate = now + timedelta(
+                days=days or 0, hours=hours or 0, minutes=minutes or 0
+            )
+
+    rc.save()
+
+    rc_index = len(manager.get_rollcalls(chat_id)) - 1
+    log_admin_action(
+        chat_id, admin_user_id, admin_name,
+        "start_template", target_name=name, details=title,
+    )
+    return serialize_rollcall(rc, max(rc_index, 0))
+
+
+# ─── Delete ───────────────────────────────────────────────────────────────────
+
+def delete_one_template(
+    chat_id: int,
+    name: str,
+    admin_user_id: int,
+    admin_name: str,
+) -> dict:
+    """
+    Delete a template. Returns {"name": ..., "deleted": True}.
+    Raises:
+      parameterMissing — name empty
+      incorrectParameter — template not found / delete failed
+    """
+    name = _validate_name(name)
+    if not get_template(chat_id, name):
+        raise incorrectParameter(f"Template '{name}' not found.")
+    ok = delete_template(chat_id, name)
+    if not ok:
+        raise incorrectParameter(f"Failed to delete template '{name}'.")
+    log_admin_action(
+        chat_id, admin_user_id, admin_name,
+        "delete_template", target_name=name,
+    )
+    return {"name": name, "deleted": True}
+
+
+# ─── Schedule ─────────────────────────────────────────────────────────────────
+
+_VALID_RECURRENCE = {"weekly", "biweekly", "monthly"}
+_VALID_WEEKDAYS = set(WEEKDAY_MAP.keys())
+
+
+def get_schedule(chat_id: int, name: str) -> dict:
+    """Return the schedule info for a template."""
+    t = get_one_template(chat_id, name)
+    return {
+        "name": name,
+        "schedule_day": t.get("schedule_day"),
+        "schedule_time": t.get("schedule_time"),
+        "schedule_enabled": t.get("schedule_enabled", False),
+        "recurrence_type": t.get("recurrence_type", "weekly"),
+        "last_scheduled_date": t.get("last_scheduled_date"),
+    }
+
+
+def set_schedule(
+    chat_id: int,
+    name: str,
+    admin_user_id: int,
+    admin_name: str,
+    recurrence_type: str = "weekly",
+    schedule_day: Optional[str] = None,
+    schedule_time: Optional[str] = None,
+    monthly_day: Optional[int] = None,
+) -> dict:
+    """
+    Set or update a template's auto-start schedule.
+
+    For weekly / biweekly: schedule_day (full weekday name) + schedule_time HH:MM.
+    For monthly: monthly_day (1-31) + schedule_time HH:MM.
+    Returns the updated schedule dict.
+
+    Raises:
+      parameterMissing — name empty or required fields missing
+      incorrectParameter — invalid recurrence type / weekday / time / template not found
+    """
+    name = _validate_name(name)
+    if not get_template(chat_id, name):
+        raise incorrectParameter(f"Template '{name}' not found.")
+    if not get_template(chat_id, name).get("event_day") or not get_template(chat_id, name).get("event_time"):
+        raise incorrectParameter(
+            f"Template '{name}' has no event_day/event_time set. "
+            "Set them first: upsert with event_day and event_time fields."
+        )
+
+    recurrence_type = recurrence_type.lower()
+    if recurrence_type not in _VALID_RECURRENCE:
+        raise incorrectParameter(
+            f"Invalid recurrence type '{recurrence_type}'. "
+            "Use: weekly, biweekly, monthly"
+        )
+
+    if recurrence_type == "monthly":
+        if monthly_day is None:
+            raise parameterMissing("monthly_day (1-31) is required for monthly schedules")
+        if not 1 <= monthly_day <= 31:
+            raise incorrectParameter("monthly_day must be 1-31")
+        if not schedule_time:
+            raise parameterMissing("schedule_time (HH:MM) is required")
+        try:
+            sh, sm = map(int, schedule_time.split(":"))
+            if not (0 <= sh < 24 and 0 <= sm < 60):
+                raise ValueError
+        except ValueError:
+            raise incorrectParameter(f"'{schedule_time}' is not a valid time. Use HH:MM")
+        sched_day_str = str(monthly_day)
+    else:
+        if not schedule_day:
+            raise parameterMissing("schedule_day (weekday name) is required")
+        sched_day_lower = schedule_day.lower()
+        if sched_day_lower not in _VALID_WEEKDAYS:
+            raise incorrectParameter(
+                f"'{schedule_day}' is not a valid weekday. "
+                "Use: monday, tuesday, wednesday, thursday, friday, saturday, sunday"
+            )
+        if not schedule_time:
+            raise parameterMissing("schedule_time (HH:MM) is required")
+        try:
+            sh, sm = map(int, schedule_time.split(":"))
+            if not (0 <= sh < 24 and 0 <= sm < 60):
+                raise ValueError
+        except ValueError:
+            raise incorrectParameter(f"'{schedule_time}' is not a valid time. Use HH:MM")
+        sched_day_str = sched_day_lower
+
+    ok = set_template_schedule(chat_id, name, sched_day_str, schedule_time, recurrence_type)
+    if not ok:
+        raise incorrectParameter("Failed to save schedule. Please try again.")
+
+    log_admin_action(
+        chat_id, admin_user_id, admin_name,
+        "schedule_template", target_name=name,
+        details=f"{recurrence_type} {sched_day_str} {schedule_time}",
+    )
+    return get_schedule(chat_id, name)
+
+
+def disable_schedule(
+    chat_id: int,
+    name: str,
+    admin_user_id: int,
+    admin_name: str,
+) -> dict:
+    """Disable auto-start for a template. Returns updated schedule dict."""
+    name = _validate_name(name)
+    if not get_template(chat_id, name):
+        raise incorrectParameter(f"Template '{name}' not found.")
+    ok = disable_template_schedule(chat_id, name)
+    if not ok:
+        raise incorrectParameter("Failed to disable schedule.")
+    log_admin_action(chat_id, admin_user_id, admin_name, "schedule_template_off", target_name=name)
+    return get_schedule(chat_id, name)
+
+
+def enable_schedule(
+    chat_id: int,
+    name: str,
+    admin_user_id: int,
+    admin_name: str,
+) -> dict:
+    """Re-enable a previously disabled schedule. Returns updated schedule dict."""
+    name = _validate_name(name)
+    if not get_template(chat_id, name):
+        raise incorrectParameter(f"Template '{name}' not found.")
+    ok = enable_template_schedule(chat_id, name)
+    if not ok:
+        raise incorrectParameter("Failed to enable schedule.")
+    log_admin_action(chat_id, admin_user_id, admin_name, "schedule_template_on", target_name=name)
+    return get_schedule(chat_id, name)


### PR DESCRIPTION
Slice 4b — template CRUD and schedule management extracted into the service layer and exposed via REST. Bot unchanged at runtime.

## Routes (8 new)

| Method | Path | Scope |
|---|---|---|
| GET | /chats/{id}/templates | read |
| GET | /chats/{id}/templates/{name} | read |
| PUT | /chats/{id}/templates/{name} | admin (partial update) |
| POST | /chats/{id}/templates/{name}/start | admin (spawns rollcall) |
| DELETE | /chats/{id}/templates/{name} | admin |
| GET | /chats/{id}/templates/{name}/schedule | read |
| PUT | /chats/{id}/templates/{name}/schedule | admin (weekly/biweekly/monthly) |
| DELETE | /chats/{id}/templates/{name}/schedule | admin (disable) |

## Bug fixed

\`schedule_enabled\` is stored as TEXT \`"1"\`/\`"0"\` by SQLite migration. \`bool("0")\` is \`True\` in Python, so \`schedule_enabled: False\` was never returned after disabling. Fixed in \`_serialize_template\`.

## Tests

- \`test_services_templates.py\` (+21)
- \`test_api_templates.py\` (+17)

## Test plan

- [x] smoke 9/9, unit 298/298, integration **529/529** (+38), functional 121/121, persistence 44/44 → **1001 total**
- [ ] CI green