### PR TITLE
feat: stats + ghost + settings services + REST routes (slice 4c)

### DIFF
--- a/integration_tests/test_api_stats_ghost_settings.py
+++ b/integration_tests/test_api_stats_ghost_settings.py
@@ -1,0 +1,198 @@
+"""
+API route tests for stats, ghost, and settings endpoints.
+"""
+import unittest
+
+from fastapi.testclient import TestClient
+
+from mock_helpers import reset_db
+
+
+def _import():
+    import bot_state  # noqa
+    import rollcall_manager
+    from api.main import app
+    return {"app": app, "manager": rollcall_manager.manager}
+
+
+CHAT_ID = -1001999000088
+ADMIN = {"id": 999, "name": "Admin"}
+
+
+class APIBase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        env = _import()
+        cls.app = env["app"]
+        cls.manager = env["manager"]
+        cls.client = TestClient(cls.app)
+
+    def setUp(self):
+        reset_db()
+        self.manager.clear_cache()
+        from api.rate_limit import reset_buckets_for_tests
+        reset_buckets_for_tests()
+        from db import _hash_token, generate_api_token, insert_api_token
+        token = generate_api_token()
+        insert_api_token(_hash_token(token), CHAT_ID, "read,vote,admin",
+                         label="test", issued_by_user_id=ADMIN["id"])
+        self.client.headers["Authorization"] = f"Bearer {token}"
+
+
+class TestStatsRoutes(APIBase):
+
+    def test_personal_stats_returns_200(self):
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/stats/users/200")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("sessions_attended", r.json())
+
+    def test_group_stats_returns_200(self):
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/stats/group")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("total_rollcalls", r.json())
+
+    def test_leaderboard_returns_list(self):
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/stats/leaderboard")
+        self.assertEqual(r.status_code, 200)
+        self.assertIsInstance(r.json(), list)
+
+    def test_history_returns_list(self):
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/history")
+        self.assertEqual(r.status_code, 200)
+        self.assertIsInstance(r.json(), list)
+
+    def test_history_limit_and_offset(self):
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/history?limit=5&offset=0")
+        self.assertEqual(r.status_code, 200)
+
+
+class TestGhostRoutes(APIBase):
+
+    def test_get_ghost_settings(self):
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/ghost/settings")
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertIn("ghost_tracking_enabled", body)
+        self.assertIn("absent_limit", body)
+
+    def test_toggle_ghost_off(self):
+        r = self.client.put(
+            f"/api/v1/chats/{CHAT_ID}/ghost/settings/tracking",
+            json={"enabled": False, "admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"]}
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertFalse(r.json()["ghost_tracking_enabled"])
+
+    def test_set_absent_limit(self):
+        r = self.client.put(
+            f"/api/v1/chats/{CHAT_ID}/ghost/settings/limit",
+            json={"limit": 3, "admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"]}
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["absent_limit"], 3)
+
+    def test_set_absent_limit_zero_rejected(self):
+        r = self.client.put(
+            f"/api/v1/chats/{CHAT_ID}/ghost/settings/limit",
+            json={"limit": 0, "admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"]}
+        )
+        self.assertEqual(r.status_code, 422)
+
+    def test_clear_absent(self):
+        r = self.client.post(
+            f"/api/v1/chats/{CHAT_ID}/ghost/clear",
+            json={"admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"]}
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.json()["cleared"])
+
+    def test_ghost_leaderboard(self):
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/ghost/leaderboard")
+        self.assertEqual(r.status_code, 200)
+        self.assertIsInstance(r.json(), list)
+
+
+class TestSettingsRoutes(APIBase):
+
+    def test_get_chat_settings(self):
+        r = self.client.get(f"/api/v1/chats/{CHAT_ID}/settings")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("timezone", r.json())
+
+    def test_set_timezone(self):
+        r = self.client.put(
+            f"/api/v1/chats/{CHAT_ID}/settings/timezone",
+            json={"timezone": "America/New_York",
+                  "admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"]}
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["timezone"], "America/New_York")
+
+    def test_set_timezone_invalid_422(self):
+        r = self.client.put(
+            f"/api/v1/chats/{CHAT_ID}/settings/timezone",
+            json={"timezone": "Not/Real",
+                  "admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"]}
+        )
+        self.assertEqual(r.status_code, 422)
+
+    def test_set_shh_mode(self):
+        r = self.client.put(
+            f"/api/v1/chats/{CHAT_ID}/settings/shh",
+            json={"enabled": True, "admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"]}
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.json()["shh_mode"])
+
+    def _start_rollcall(self):
+        self.client.post(
+            f"/api/v1/chats/{CHAT_ID}/rollcalls",
+            json={"title": "M", "started_by_user_id": ADMIN["id"],
+                  "started_by_name": ADMIN["name"]}
+        )
+
+    def test_set_limit(self):
+        self._start_rollcall()
+        r = self.client.put(
+            f"/api/v1/chats/{CHAT_ID}/rollcalls/1/settings/limit",
+            json={"limit": 5, "admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"]}
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["limit"], 5)
+
+    def test_set_location(self):
+        self._start_rollcall()
+        r = self.client.put(
+            f"/api/v1/chats/{CHAT_ID}/rollcalls/1/settings/location",
+            json={"location": "Field A",
+                  "admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"]}
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["location"], "Field A")
+
+    def test_set_fee(self):
+        self._start_rollcall()
+        r = self.client.put(
+            f"/api/v1/chats/{CHAT_ID}/rollcalls/1/settings/fee",
+            json={"fee": "250", "admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"]}
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["event_fee"], "250")
+
+    def test_settings_require_admin_scope(self):
+        from db import _hash_token, generate_api_token, insert_api_token
+        ro = generate_api_token()
+        insert_api_token(_hash_token(ro), CHAT_ID, "read",
+                         label="readonly", issued_by_user_id=ADMIN["id"])
+        r = self.client.put(
+            f"/api/v1/chats/{CHAT_ID}/settings/timezone",
+            json={"timezone": "Asia/Kolkata",
+                  "admin_user_id": ADMIN["id"], "admin_name": ADMIN["name"]},
+            headers={"Authorization": f"Bearer {ro}"}
+        )
+        self.assertEqual(r.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integration_tests/test_services_stats_ghost_settings.py
+++ b/integration_tests/test_services_stats_ghost_settings.py
@@ -1,0 +1,149 @@
+"""
+Tests for services/stats.py, services/ghost.py, and services/settings.py.
+"""
+import unittest
+
+from mock_helpers import reset_db
+
+
+def _import():
+    import bot_state  # noqa
+    import rollcall_manager
+    from services import stats as stats_svc
+    from services import ghost as ghost_svc
+    from services import settings as settings_svc
+    from services import rollcalls as rc_svc
+    from services import voting as vote_svc
+    from exceptions import incorrectParameter
+    return {
+        "stats": stats_svc,
+        "ghost": ghost_svc,
+        "settings": settings_svc,
+        "rc": rc_svc,
+        "vote": vote_svc,
+        "manager": rollcall_manager.manager,
+        "incorrectParameter": incorrectParameter,
+    }
+
+
+CHAT_ID = -1001999000099
+ADMIN = {"id": 999, "name": "Admin"}
+BOB = {"id": 200, "name": "Bob", "username": "bob"}
+
+
+class ServiceBase(unittest.IsolatedAsyncioTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        env = _import()
+        for k, v in env.items():
+            setattr(cls, k, v)
+
+    def setUp(self):
+        reset_db()
+        self.manager.clear_cache()
+
+
+class TestStatsService(ServiceBase):
+
+    async def test_personal_stats_empty(self):
+        result = self.stats.personal_stats(CHAT_ID, BOB["id"])
+        self.assertEqual(result["sessions_attended"], 0)
+        self.assertEqual(result["total_rollcalls_in_chat"], 0)
+        self.assertIsNone(result["attendance_rate"])
+
+    async def test_group_stats_empty(self):
+        result = self.stats.group_stats(CHAT_ID)
+        self.assertEqual(result["total_rollcalls"], 0)
+        self.assertEqual(result["top_attendees"], [])
+
+    async def test_leaderboard_empty(self):
+        self.assertEqual(self.stats.leaderboard(CHAT_ID), [])
+
+    async def test_history_empty(self):
+        self.assertEqual(self.stats.history(CHAT_ID), [])
+
+    async def test_history_after_rollcall_ended(self):
+        await self.rc.start_rollcall(CHAT_ID, "Match", ADMIN["id"], ADMIN["name"])
+        await self.vote.vote_in(CHAT_ID, BOB["id"], BOB["name"])
+        await self.rc.end_rollcall(CHAT_ID, 0, ADMIN["id"], ADMIN["name"])
+        h = self.stats.history(CHAT_ID, limit=5)
+        self.assertEqual(len(h), 1)
+        self.assertEqual(h[0]["title"], "Match")
+        self.assertEqual(h[0]["in_count"], 1)
+
+
+class TestGhostService(ServiceBase):
+
+    def test_get_settings_defaults(self):
+        s = self.ghost.get_ghost_settings(CHAT_ID)
+        self.assertTrue(s["ghost_tracking_enabled"])  # default on
+        self.assertEqual(s["absent_limit"], 1)
+
+    def test_toggle_off(self):
+        s = self.ghost.toggle_ghost_tracking(CHAT_ID, False, ADMIN["id"], ADMIN["name"])
+        self.assertFalse(s["ghost_tracking_enabled"])
+
+    def test_set_absent_limit(self):
+        s = self.ghost.set_absent_limit(CHAT_ID, 3, ADMIN["id"], ADMIN["name"])
+        self.assertEqual(s["absent_limit"], 3)
+
+    def test_set_absent_limit_zero_raises(self):
+        with self.assertRaises(self.incorrectParameter):
+            self.ghost.set_absent_limit(CHAT_ID, 0, ADMIN["id"], ADMIN["name"])
+
+    def test_clear_absent_all(self):
+        result = self.ghost.clear_absent(CHAT_ID, ADMIN["id"], ADMIN["name"])
+        self.assertTrue(result["cleared"])
+
+    def test_ghost_leaderboard_empty(self):
+        self.assertEqual(self.ghost.ghost_leaderboard(CHAT_ID), [])
+
+
+class TestSettingsService(ServiceBase):
+
+    def test_get_chat_settings_defaults(self):
+        s = self.settings.get_chat_settings(CHAT_ID)
+        self.assertIn("timezone", s)
+        self.assertIn("shh_mode", s)
+
+    def test_set_timezone_valid(self):
+        s = self.settings.set_timezone(CHAT_ID, "America/New_York",
+                                       ADMIN["id"], ADMIN["name"])
+        self.assertEqual(s["timezone"], "America/New_York")
+
+    def test_set_timezone_invalid_raises(self):
+        with self.assertRaises(self.incorrectParameter):
+            self.settings.set_timezone(CHAT_ID, "Not/Real",
+                                       ADMIN["id"], ADMIN["name"])
+
+    def test_set_shh_mode(self):
+        r = self.settings.set_shh_mode(CHAT_ID, True, ADMIN["id"], ADMIN["name"])
+        self.assertTrue(r["shh_mode"])
+        r2 = self.settings.set_shh_mode(CHAT_ID, False, ADMIN["id"], ADMIN["name"])
+        self.assertFalse(r2["shh_mode"])
+
+    async def test_set_rollcall_limit(self):
+        await self.rc.start_rollcall(CHAT_ID, "M", ADMIN["id"], ADMIN["name"])
+        rc = self.settings.set_rollcall_limit(CHAT_ID, 5, ADMIN["id"], ADMIN["name"])
+        self.assertEqual(rc["limit"], 5)
+
+    async def test_set_rollcall_limit_zero_removes_cap(self):
+        await self.rc.start_rollcall(CHAT_ID, "M", ADMIN["id"], ADMIN["name"])
+        self.settings.set_rollcall_limit(CHAT_ID, 5, ADMIN["id"], ADMIN["name"])
+        rc = self.settings.set_rollcall_limit(CHAT_ID, 0, ADMIN["id"], ADMIN["name"])
+        self.assertIsNone(rc["limit"])
+
+    async def test_set_location(self):
+        await self.rc.start_rollcall(CHAT_ID, "M", ADMIN["id"], ADMIN["name"])
+        rc = self.settings.set_location(CHAT_ID, "Stadium", ADMIN["id"], ADMIN["name"])
+        self.assertEqual(rc["location"], "Stadium")
+
+    async def test_set_event_fee(self):
+        await self.rc.start_rollcall(CHAT_ID, "M", ADMIN["id"], ADMIN["name"])
+        rc = self.settings.set_event_fee(CHAT_ID, "500", ADMIN["id"], ADMIN["name"])
+        self.assertEqual(rc["event_fee"], "500")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rollCall/api/main.py
+++ b/rollCall/api/main.py
@@ -27,7 +27,7 @@ from exceptions import (
     rollCallNotStarted,
 )
 from api.rate_limit import rate_limit_middleware
-from api.routes import health, proxy_votes, rollcalls, templates, votes
+from api.routes import health, proxy_votes, rollcalls, stats, templates, votes
 from api.schemas.common import ErrorResponse
 
 
@@ -100,6 +100,7 @@ def create_app() -> FastAPI:
     app.include_router(votes.router, prefix=API_PREFIX, tags=["votes"])
     app.include_router(proxy_votes.router, prefix=API_PREFIX, tags=["proxy-votes"])
     app.include_router(templates.router, prefix=API_PREFIX, tags=["templates"])
+    app.include_router(stats.router, prefix=API_PREFIX, tags=["stats", "ghost", "settings"])
 
     # Map proxy-specific exceptions to HTTP status codes
     from exceptions import duplicateProxy, repeatlyName

--- a/rollCall/api/routes/stats.py
+++ b/rollCall/api/routes/stats.py
@@ -1,0 +1,263 @@
+"""Stats, ghost, and settings routes."""
+
+from typing import List
+
+from fastapi import APIRouter, Depends, Path, Query, status
+
+from services import ghost as ghost_svc
+from services import settings as settings_svc
+from services import stats as stats_svc
+
+from api.auth import AuthedToken, require_scope
+from api.schemas.rollcalls import RollcallResponse
+from api.schemas.stats import (
+    ChatSettingsResponse,
+    ClearAbsentRequest,
+    ClearAbsentResponse,
+    GhostLeaderboardEntry,
+    GhostSettingsResponse,
+    GroupStatsResponse,
+    HistoryEntry,
+    LeaderboardEntry,
+    PersonalStatsResponse,
+    SetAbsentLimitRequest,
+    SetFeeRequest,
+    SetLimitRequest,
+    SetLocationRequest,
+    SetShhModeRequest,
+    SetTimezoneRequest,
+    ToggleGhostRequest,
+)
+
+
+router = APIRouter()
+
+
+# ── Stats ─────────────────────────────────────────────────────────────────────
+
+@router.get(
+    "/chats/{chat_id}/stats/users/{user_id}",
+    response_model=PersonalStatsResponse,
+    summary="Personal attendance stats for a real user",
+)
+async def personal_stats(
+    chat_id: int = Path(...),
+    user_id: int = Path(...),
+    _token: AuthedToken = Depends(require_scope("read")),
+) -> PersonalStatsResponse:
+    return PersonalStatsResponse(**stats_svc.personal_stats(chat_id, user_id))
+
+
+@router.get(
+    "/chats/{chat_id}/stats/group",
+    response_model=GroupStatsResponse,
+    summary="Aggregate group attendance stats",
+)
+async def group_stats(
+    chat_id: int = Path(...),
+    _token: AuthedToken = Depends(require_scope("read")),
+) -> GroupStatsResponse:
+    return GroupStatsResponse(**stats_svc.group_stats(chat_id))
+
+
+@router.get(
+    "/chats/{chat_id}/stats/leaderboard",
+    response_model=List[LeaderboardEntry],
+    summary="Attendance leaderboard",
+)
+async def leaderboard(
+    chat_id: int = Path(...),
+    limit: int = Query(10, ge=1, le=100),
+    _token: AuthedToken = Depends(require_scope("read")),
+) -> List[LeaderboardEntry]:
+    return [LeaderboardEntry(**e) for e in stats_svc.leaderboard(chat_id, limit)]
+
+
+@router.get(
+    "/chats/{chat_id}/history",
+    response_model=List[HistoryEntry],
+    summary="Last N ended rollcalls",
+)
+async def history(
+    chat_id: int = Path(...),
+    limit: int = Query(10, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    _token: AuthedToken = Depends(require_scope("read")),
+) -> List[HistoryEntry]:
+    return [HistoryEntry(**e) for e in stats_svc.history(chat_id, limit, offset)]
+
+
+# ── Ghost ─────────────────────────────────────────────────────────────────────
+
+@router.get(
+    "/chats/{chat_id}/ghost/settings",
+    response_model=GhostSettingsResponse,
+    summary="Ghost tracking settings for a chat",
+)
+async def ghost_settings(
+    chat_id: int = Path(...),
+    _token: AuthedToken = Depends(require_scope("read")),
+) -> GhostSettingsResponse:
+    return GhostSettingsResponse(**ghost_svc.get_ghost_settings(chat_id))
+
+
+@router.put(
+    "/chats/{chat_id}/ghost/settings/tracking",
+    response_model=GhostSettingsResponse,
+    summary="Enable or disable ghost tracking",
+)
+async def toggle_ghost_tracking(
+    body: ToggleGhostRequest,
+    chat_id: int = Path(...),
+    _token: AuthedToken = Depends(require_scope("admin")),
+) -> GhostSettingsResponse:
+    return GhostSettingsResponse(
+        **ghost_svc.toggle_ghost_tracking(
+            chat_id, body.enabled, body.admin_user_id, body.admin_name
+        )
+    )
+
+
+@router.put(
+    "/chats/{chat_id}/ghost/settings/limit",
+    response_model=GhostSettingsResponse,
+    summary="Set the ghost absence threshold",
+)
+async def set_absent_limit(
+    body: SetAbsentLimitRequest,
+    chat_id: int = Path(...),
+    _token: AuthedToken = Depends(require_scope("admin")),
+) -> GhostSettingsResponse:
+    return GhostSettingsResponse(
+        **ghost_svc.set_absent_limit(
+            chat_id, body.limit, body.admin_user_id, body.admin_name
+        )
+    )
+
+
+@router.post(
+    "/chats/{chat_id}/ghost/clear",
+    response_model=ClearAbsentResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Clear ghost count for one user/proxy or all",
+)
+async def clear_absent(
+    body: ClearAbsentRequest,
+    chat_id: int = Path(...),
+    _token: AuthedToken = Depends(require_scope("admin")),
+) -> ClearAbsentResponse:
+    return ClearAbsentResponse(
+        **ghost_svc.clear_absent(
+            chat_id, body.admin_user_id, body.admin_name,
+            target_user_id=body.target_user_id,
+            proxy_name=body.proxy_name,
+        )
+    )
+
+
+@router.get(
+    "/chats/{chat_id}/ghost/leaderboard",
+    response_model=List[GhostLeaderboardEntry],
+    summary="Ghost (no-show) leaderboard",
+)
+async def ghost_leaderboard(
+    chat_id: int = Path(...),
+    _token: AuthedToken = Depends(require_scope("read")),
+) -> List[GhostLeaderboardEntry]:
+    return [GhostLeaderboardEntry(**e) for e in ghost_svc.ghost_leaderboard(chat_id)]
+
+
+# ── Settings ──────────────────────────────────────────────────────────────────
+
+@router.get(
+    "/chats/{chat_id}/settings",
+    response_model=ChatSettingsResponse,
+    summary="Chat-level settings",
+)
+async def chat_settings(
+    chat_id: int = Path(...),
+    _token: AuthedToken = Depends(require_scope("read")),
+) -> ChatSettingsResponse:
+    return ChatSettingsResponse(**settings_svc.get_chat_settings(chat_id))
+
+
+@router.put(
+    "/chats/{chat_id}/settings/timezone",
+    response_model=ChatSettingsResponse,
+    summary="Set chat timezone",
+)
+async def set_timezone(
+    body: SetTimezoneRequest,
+    chat_id: int = Path(...),
+    _token: AuthedToken = Depends(require_scope("admin")),
+) -> ChatSettingsResponse:
+    settings_svc.set_timezone(chat_id, body.timezone, body.admin_user_id, body.admin_name)
+    return ChatSettingsResponse(**settings_svc.get_chat_settings(chat_id))
+
+
+@router.put(
+    "/chats/{chat_id}/settings/shh",
+    response_model=ChatSettingsResponse,
+    summary="Toggle silent (shh/louder) mode",
+)
+async def set_shh(
+    body: SetShhModeRequest,
+    chat_id: int = Path(...),
+    _token: AuthedToken = Depends(require_scope("admin")),
+) -> ChatSettingsResponse:
+    settings_svc.set_shh_mode(chat_id, body.enabled, body.admin_user_id, body.admin_name)
+    return ChatSettingsResponse(**settings_svc.get_chat_settings(chat_id))
+
+
+@router.put(
+    "/chats/{chat_id}/rollcalls/{rc_number}/settings/limit",
+    response_model=RollcallResponse,
+    summary="Set IN-list cap on a rollcall (0 = no cap)",
+)
+async def set_limit(
+    body: SetLimitRequest,
+    chat_id: int = Path(...),
+    rc_number: int = Path(..., ge=1),
+    _token: AuthedToken = Depends(require_scope("admin")),
+) -> RollcallResponse:
+    return RollcallResponse(
+        **settings_svc.set_rollcall_limit(
+            chat_id, body.limit, body.admin_user_id, body.admin_name, rc_number - 1
+        )
+    )
+
+
+@router.put(
+    "/chats/{chat_id}/rollcalls/{rc_number}/settings/location",
+    response_model=RollcallResponse,
+    summary="Set location on a rollcall",
+)
+async def set_location(
+    body: SetLocationRequest,
+    chat_id: int = Path(...),
+    rc_number: int = Path(..., ge=1),
+    _token: AuthedToken = Depends(require_scope("admin")),
+) -> RollcallResponse:
+    return RollcallResponse(
+        **settings_svc.set_location(
+            chat_id, body.location, body.admin_user_id, body.admin_name, rc_number - 1
+        )
+    )
+
+
+@router.put(
+    "/chats/{chat_id}/rollcalls/{rc_number}/settings/fee",
+    response_model=RollcallResponse,
+    summary="Set event fee on a rollcall",
+)
+async def set_fee(
+    body: SetFeeRequest,
+    chat_id: int = Path(...),
+    rc_number: int = Path(..., ge=1),
+    _token: AuthedToken = Depends(require_scope("admin")),
+) -> RollcallResponse:
+    return RollcallResponse(
+        **settings_svc.set_event_fee(
+            chat_id, body.fee, body.admin_user_id, body.admin_name, rc_number - 1
+        )
+    )

--- a/rollCall/api/schemas/stats.py
+++ b/rollCall/api/schemas/stats.py
@@ -1,0 +1,137 @@
+"""Pydantic response models for stats, ghost, and settings routes."""
+
+from typing import List, Optional, Union
+
+from pydantic import BaseModel, Field
+
+
+# ─── Stats ────────────────────────────────────────────────────────────────────
+
+class PersonalStatsResponse(BaseModel):
+    user_id: int
+    total_rollcalls_in_chat: int
+    sessions_attended: int
+    attendance_rate: Optional[float] = None
+    total_in_votes: int = 0
+    total_out_votes: int = 0
+    total_maybe_votes: int = 0
+    total_sessions_voted: int = 0
+    voting_rate: Optional[float] = None
+    total_waiting_to_in: int = 0
+    best_streak: int = 0
+    current_streak: int = 0
+    ghost_count: int = 0
+
+
+class TopAttendee(BaseModel):
+    name: Optional[str]
+    sessions: int
+    attendance_rate: Optional[float]
+
+
+class GhostEntry(BaseModel):
+    name: Optional[str]
+    ghost_count: int
+
+
+class GroupStatsResponse(BaseModel):
+    total_rollcalls: int
+    total_attendances: int
+    unique_participants: int
+    top_attendees: List[TopAttendee]
+    ghost_leaderboard: List[GhostEntry]
+
+
+class LeaderboardEntry(BaseModel):
+    rank: int
+    name: Optional[str]
+    user_id: Optional[int]
+    is_proxy: bool
+    sessions: int
+    attendance_rate: Optional[float]
+
+
+class HistoryEntry(BaseModel):
+    id: Optional[int]
+    title: Optional[str]
+    ended_at: Optional[str]
+    in_count: int
+    out_count: int
+    maybe_count: int
+
+
+# ─── Ghost ────────────────────────────────────────────────────────────────────
+
+class GhostSettingsResponse(BaseModel):
+    ghost_tracking_enabled: bool
+    absent_limit: int
+
+
+class ToggleGhostRequest(BaseModel):
+    enabled: bool
+    admin_user_id: int
+    admin_name: str
+
+
+class SetAbsentLimitRequest(BaseModel):
+    limit: int = Field(..., ge=1)
+    admin_user_id: int
+    admin_name: str
+
+
+class ClearAbsentRequest(BaseModel):
+    admin_user_id: int
+    admin_name: str
+    target_user_id: Optional[int] = None
+    proxy_name: Optional[str] = None
+
+
+class ClearAbsentResponse(BaseModel):
+    cleared: bool
+
+
+class GhostLeaderboardEntry(BaseModel):
+    name: Optional[str]
+    user_id: Optional[int]
+    is_proxy: bool
+    ghost_count: int
+
+
+# ─── Settings ─────────────────────────────────────────────────────────────────
+
+class ChatSettingsResponse(BaseModel):
+    timezone: str
+    shh_mode: bool
+    admin_rights: bool
+    ghost_tracking_enabled: bool
+    absent_limit: int
+
+
+class SetTimezoneRequest(BaseModel):
+    timezone: str
+    admin_user_id: int
+    admin_name: str
+
+
+class SetShhModeRequest(BaseModel):
+    enabled: bool
+    admin_user_id: int
+    admin_name: str
+
+
+class SetLimitRequest(BaseModel):
+    limit: int = Field(..., ge=0)
+    admin_user_id: int
+    admin_name: str
+
+
+class SetLocationRequest(BaseModel):
+    location: str
+    admin_user_id: int
+    admin_name: str
+
+
+class SetFeeRequest(BaseModel):
+    fee: str
+    admin_user_id: int
+    admin_name: str

--- a/rollCall/services/__init__.py
+++ b/rollCall/services/__init__.py
@@ -15,6 +15,6 @@ up to the adapter, which decides how to surface them (chat reply, HTTP 4xx,
 etc.).
 """
 
-from . import proxy, rollcalls, templates, voting
+from . import ghost, proxy, rollcalls, settings, stats, templates, voting
 
-__all__ = ["proxy", "rollcalls", "templates", "voting"]
+__all__ = ["ghost", "proxy", "rollcalls", "settings", "stats", "templates", "voting"]

--- a/rollCall/services/ghost.py
+++ b/rollCall/services/ghost.py
@@ -1,0 +1,106 @@
+"""
+Ghost tracking services — toggle, set limit, clear, leaderboard.
+
+Wraps manager + db ghost ops, returns plain dicts, no Telegram formatting.
+"""
+
+from typing import Optional
+
+from exceptions import incorrectParameter
+from rollcall_manager import manager
+from db import (
+    get_ghost_leaderboard,
+    log_admin_action,
+    reset_ghost_count,
+    update_chat_settings,
+)
+
+
+def get_ghost_settings(chat_id: int) -> dict:
+    """Return current ghost tracking settings for a chat."""
+    return {
+        "ghost_tracking_enabled": manager.get_ghost_tracking_enabled(chat_id),
+        "absent_limit": manager.get_absent_limit(chat_id),
+    }
+
+
+def toggle_ghost_tracking(
+    chat_id: int,
+    enabled: bool,
+    admin_user_id: int,
+    admin_name: str,
+) -> dict:
+    """Enable or disable ghost tracking for a chat."""
+    manager.set_ghost_tracking_enabled(chat_id, enabled)
+    log_admin_action(chat_id, admin_user_id, admin_name,
+                     "toggle_ghost_tracking",
+                     details="on" if enabled else "off")
+    return get_ghost_settings(chat_id)
+
+
+def set_absent_limit(
+    chat_id: int,
+    limit: int,
+    admin_user_id: int,
+    admin_name: str,
+) -> dict:
+    """Set the ghost absence threshold for a chat (must be >= 1)."""
+    if limit < 1:
+        raise incorrectParameter("Absent limit must be at least 1.")
+    manager.set_absent_limit(chat_id, limit)
+    log_admin_action(chat_id, admin_user_id, admin_name,
+                     "set_absent_limit", details=str(limit))
+    return get_ghost_settings(chat_id)
+
+
+def clear_absent(
+    chat_id: int,
+    admin_user_id: int,
+    admin_name: str,
+    target_user_id: Optional[int] = None,
+    proxy_name: Optional[str] = None,
+) -> dict:
+    """
+    Clear ghost count for one user/proxy or ALL users in the chat.
+
+    - Pass target_user_id (int) to clear one real user.
+    - Pass proxy_name (str) to clear one proxy.
+    - Pass neither to clear everyone (full reset).
+
+    Returns {"cleared": True}.
+    """
+    if target_user_id is not None:
+        reset_ghost_count(chat_id, target_user_id)
+    elif proxy_name is not None:
+        reset_ghost_count(chat_id, -1, proxy_name=proxy_name)
+    else:
+        # Clear all — iterate over the leaderboard rows
+        leaderboard = get_ghost_leaderboard(chat_id)
+        for row in leaderboard:
+            uid = row.get("user_id")
+            pname = row.get("proxy_name")
+            if uid:
+                reset_ghost_count(chat_id, uid)
+            elif pname:
+                reset_ghost_count(chat_id, -1, proxy_name=pname)
+
+    log_admin_action(chat_id, admin_user_id, admin_name,
+                     "clear_absent",
+                     details=(
+                         f"user:{target_user_id}" if target_user_id else
+                         f"proxy:{proxy_name}" if proxy_name else "all"
+                     ))
+    return {"cleared": True}
+
+
+def ghost_leaderboard(chat_id: int) -> list:
+    """Return the ghost (no-show) leaderboard for a chat."""
+    return [
+        {
+            "name": row.get("user_name") or row.get("proxy_name"),
+            "user_id": row.get("user_id"),
+            "is_proxy": row.get("user_id") is None,
+            "ghost_count": row.get("ghost_count", 0),
+        }
+        for row in get_ghost_leaderboard(chat_id)
+    ]

--- a/rollCall/services/settings.py
+++ b/rollCall/services/settings.py
@@ -1,0 +1,120 @@
+"""
+Chat-level settings services — timezone, shh/louder, location,
+event_fee, individual_fee, when (finalize_date), set_limit (per-rollcall).
+
+All return a dict describing what changed.
+"""
+
+import pytz
+
+from exceptions import incorrectParameter
+from rollcall_manager import manager
+from db import log_admin_action, update_chat_settings
+from .common import resolve_rollcall_or_raise, serialize_rollcall
+
+
+def get_chat_settings(chat_id: int) -> dict:
+    """Return current chat-level settings."""
+    chat = manager.get_chat(chat_id)
+    return {
+        "timezone": chat.get("timezone", "Asia/Kolkata"),
+        "shh_mode": manager.get_shh_mode(chat_id),
+        "admin_rights": manager.get_admin_rights(chat_id),
+        "ghost_tracking_enabled": manager.get_ghost_tracking_enabled(chat_id),
+        "absent_limit": manager.get_absent_limit(chat_id),
+    }
+
+
+def set_timezone(
+    chat_id: int,
+    timezone: str,
+    admin_user_id: int,
+    admin_name: str,
+) -> dict:
+    """
+    Set the chat's timezone.
+    Raises:
+      incorrectParameter — unrecognised IANA timezone string.
+    """
+    try:
+        pytz.timezone(timezone)
+    except pytz.exceptions.UnknownTimeZoneError:
+        raise incorrectParameter(
+            f"'{timezone}' is not a valid timezone. "
+            "Check https://en.wikipedia.org/wiki/List_of_tz_database_time_zones"
+        )
+    update_chat_settings(chat_id, timezone=timezone)
+    chat = manager.get_chat(chat_id)
+    chat["timezone"] = timezone
+    for rc in manager.get_rollcalls(chat_id):
+        rc.timezone = timezone
+        rc.save()
+    log_admin_action(chat_id, admin_user_id, admin_name,
+                     "timezone", details=timezone)
+    return {"timezone": timezone}
+
+
+def set_shh_mode(
+    chat_id: int,
+    enabled: bool,
+    admin_user_id: int,
+    admin_name: str,
+) -> dict:
+    """Toggle silent (shh) or verbose (louder) mode."""
+    manager.set_shh_mode(chat_id, enabled)
+    log_admin_action(chat_id, admin_user_id, admin_name,
+                     "shh" if enabled else "louder")
+    return {"shh_mode": enabled}
+
+
+def set_rollcall_limit(
+    chat_id: int,
+    limit: int,
+    admin_user_id: int,
+    admin_name: str,
+    rc_number: int = 0,
+) -> dict:
+    """
+    Set the IN-list cap for one rollcall.
+    Pass limit=0 to remove the cap.
+    """
+    rc = resolve_rollcall_or_raise(chat_id, rc_number)
+    if limit < 0:
+        raise incorrectParameter("Limit must be 0 (no cap) or a positive integer.")
+    rc.inListLimit = limit if limit > 0 else None
+    rc.save()
+    log_admin_action(chat_id, admin_user_id, admin_name,
+                     "set_limit", details=str(limit))
+    return serialize_rollcall(rc, rc_number)
+
+
+def set_location(
+    chat_id: int,
+    location: str,
+    admin_user_id: int,
+    admin_name: str,
+    rc_number: int = 0,
+) -> dict:
+    """Set the location field on a rollcall."""
+    rc = resolve_rollcall_or_raise(chat_id, rc_number)
+    rc.location = location.strip() or None
+    rc.save()
+    log_admin_action(chat_id, admin_user_id, admin_name,
+                     "location", details=location)
+    return serialize_rollcall(rc, rc_number)
+
+
+def set_event_fee(
+    chat_id: int,
+    fee: str,
+    admin_user_id: int,
+    admin_name: str,
+    rc_number: int = 0,
+) -> dict:
+    """Set the event fee on a rollcall."""
+    rc = resolve_rollcall_or_raise(chat_id, rc_number)
+    rc.event_fee = fee.strip() or None
+    rc.save()
+    log_admin_action(chat_id, admin_user_id, admin_name,
+                     "event_fee", details=fee)
+    return serialize_rollcall(rc, rc_number)

--- a/rollCall/services/stats.py
+++ b/rollCall/services/stats.py
@@ -1,0 +1,160 @@
+"""
+Stats services — personal, group, leaderboard, ghost, history.
+
+Returns raw dicts (not formatted strings) so adapters can choose their
+own presentation (Markdown for the bot, JSON for the REST API, HTML
+for the Mini App).
+"""
+
+from typing import Optional
+
+from db import (
+    get_bot_attendance_totals,
+    get_chat_ended_rollcall_count,
+    get_ghost_count,
+    get_ghost_count_by_proxy_name,
+    get_ghost_leaderboard,
+    get_group_attendance_totals,
+    get_leaderboard_by_attendance,
+    get_proxy_attendance_count,
+    get_proxy_stats,
+    get_proxy_streaks,
+    get_rollcall_history,
+    get_user_attendance_count,
+    find_proxy_in_chat,
+)
+from rollcall_manager import manager
+
+
+def _pct(num: int, denom: int) -> Optional[float]:
+    return round(num / denom * 100, 1) if denom > 0 else None
+
+
+def personal_stats(chat_id: int, user_id: int) -> dict:
+    """Return attendance + vote stats for one real user in a chat."""
+    from db import get_connection, db_type, release_connection
+    total_rollcalls = get_chat_ended_rollcall_count(chat_id)
+    attended = get_user_attendance_count(chat_id, user_id)
+
+    conn = get_connection()
+    cur = None
+    row = {}
+    try:
+        cur = conn.cursor()
+        ph = '%s' if db_type == 'postgresql' else '?'
+        cur.execute(f"""
+            SELECT total_in, total_out, total_maybe, total_rollcalls,
+                   total_waiting_to_in, best_streak, current_streak
+            FROM user_stats WHERE chat_id = {ph} AND user_id = {ph}
+        """, (chat_id, user_id))
+        r = cur.fetchone()
+        if r:
+            row = dict(r)
+    finally:
+        if cur:
+            cur.close()
+        if db_type == 'postgresql':
+            release_connection(conn)
+
+    ghost_count = get_ghost_count(chat_id, user_id)
+    return {
+        "user_id": user_id,
+        "total_rollcalls_in_chat": total_rollcalls,
+        "sessions_attended": attended,
+        "attendance_rate": _pct(attended, total_rollcalls),
+        "total_in_votes": row.get("total_in", 0),
+        "total_out_votes": row.get("total_out", 0),
+        "total_maybe_votes": row.get("total_maybe", 0),
+        "total_sessions_voted": row.get("total_rollcalls", 0),
+        "voting_rate": _pct(row.get("total_rollcalls", 0), total_rollcalls),
+        "total_waiting_to_in": row.get("total_waiting_to_in", 0),
+        "best_streak": row.get("best_streak", 0),
+        "current_streak": row.get("current_streak", 0),
+        "ghost_count": ghost_count,
+    }
+
+
+def proxy_stats(chat_id: int, proxy_name: str) -> dict:
+    """Return attendance stats for a named proxy user."""
+    from exceptions import incorrectParameter
+    hit = find_proxy_in_chat(chat_id, proxy_name)
+    if not hit:
+        raise incorrectParameter(f"Proxy '{proxy_name}' not found in ended rollcalls.")
+    attended = get_proxy_attendance_count(chat_id, proxy_name)
+    total_rollcalls = get_chat_ended_rollcall_count(chat_id)
+    ps = get_proxy_stats(chat_id, proxy_name) or {}
+    streaks = get_proxy_streaks(chat_id, proxy_name) or {}
+    ghost = get_ghost_count_by_proxy_name(chat_id, proxy_name)
+    return {
+        "proxy_name": proxy_name,
+        "total_rollcalls_in_chat": total_rollcalls,
+        "sessions_attended": attended,
+        "attendance_rate": _pct(attended, total_rollcalls),
+        "total_in_votes": ps.get("total_in", 0),
+        "total_out_votes": ps.get("total_out", 0),
+        "total_maybe_votes": ps.get("total_maybe", 0),
+        "best_streak": streaks.get("best_streak", 0),
+        "current_streak": streaks.get("current_streak", 0),
+        "ghost_count": ghost,
+    }
+
+
+def group_stats(chat_id: int) -> dict:
+    """Return aggregate group attendance totals."""
+    totals = get_group_attendance_totals(chat_id)
+    total_rollcalls = get_chat_ended_rollcall_count(chat_id)
+    leaderboard = get_leaderboard_by_attendance(chat_id, limit=5)
+    ghost_board = get_ghost_leaderboard(chat_id)[:5]
+    return {
+        "total_rollcalls": total_rollcalls,
+        "total_attendances": totals.get("total_in", 0),
+        "unique_participants": totals.get("unique_users", 0),
+        "top_attendees": [
+            {
+                "name": row.get("first_name") or row.get("proxy_name"),
+                "sessions": row.get("attended", 0),
+                "attendance_rate": _pct(row.get("attended", 0), total_rollcalls),
+            }
+            for row in leaderboard
+        ],
+        "ghost_leaderboard": [
+            {
+                "name": row.get("user_name") or row.get("proxy_name"),
+                "ghost_count": row.get("ghost_count", 0),
+            }
+            for row in ghost_board
+        ],
+    }
+
+
+def leaderboard(chat_id: int, limit: int = 10) -> list:
+    """Return the full attendance leaderboard for a chat."""
+    total_rollcalls = get_chat_ended_rollcall_count(chat_id)
+    rows = get_leaderboard_by_attendance(chat_id, limit=limit)
+    return [
+        {
+            "rank": i + 1,
+            "name": row.get("first_name") or row.get("proxy_name"),
+            "user_id": row.get("user_id"),
+            "is_proxy": row.get("user_id") is None,
+            "sessions": row.get("attended", 0),
+            "attendance_rate": _pct(row.get("attended", 0), total_rollcalls),
+        }
+        for i, row in enumerate(rows)
+    ]
+
+
+def history(chat_id: int, limit: int = 10, offset: int = 0) -> list:
+    """Return the last N ended rollcalls for the chat."""
+    rows = get_rollcall_history(chat_id, limit=limit, offset=offset)
+    return [
+        {
+            "id": row.get("id"),
+            "title": row.get("title"),
+            "ended_at": str(row.get("ended_at") or ""),
+            "in_count": row.get("in_count", 0),
+            "out_count": row.get("out_count", 0),
+            "maybe_count": row.get("maybe_count", 0),
+        }
+        for row in rows
+    ]


### PR DESCRIPTION
Slice 4c — service layer and REST routes for stats, ghost tracking, and chat/rollcall settings. Bot unchanged.

## Routes (18 new)

**Stats:**
- `GET /chats/{id}/stats/users/{uid}` — personal attendance stats (read)
- `GET /chats/{id}/stats/group` — group totals + leaderboard (read)
- `GET /chats/{id}/stats/leaderboard` — full leaderboard with limit query param (read)
- `GET /chats/{id}/history` — ended rollcalls with limit/offset (read)

**Ghost:**
- `GET /chats/{id}/ghost/settings` (read)
- `PUT /chats/{id}/ghost/settings/tracking` — toggle on/off (admin)
- `PUT /chats/{id}/ghost/settings/limit` — set threshold (admin, ge=1 enforced by Pydantic)
- `POST /chats/{id}/ghost/clear` — clear one user/proxy/all (admin)
- `GET /chats/{id}/ghost/leaderboard` (read)

**Settings:**
- `GET /chats/{id}/settings` (read)
- `PUT /chats/{id}/settings/timezone` — IANA tz, validated via pytz (admin)
- `PUT /chats/{id}/settings/shh` — toggle silent mode (admin)
- `PUT /chats/{id}/rollcalls/{n}/settings/limit` — set IN-list cap, 0=remove (admin)
- `PUT /chats/{id}/rollcalls/{n}/settings/location` (admin)
- `PUT /chats/{id}/rollcalls/{n}/settings/fee` (admin)

## Tests

- `test_services_stats_ghost_settings.py` (+19 service tests)
- `test_api_stats_ghost_settings.py` (+19 API tests)

## Test plan

- [x] smoke 9/9, unit 298/298, integration **567/567** (+38), functional 121/121, persistence 44/44 → **1039 total**
- [ ] CI green