### PR TITLE
fix: update tests for service-layer refactor; restore reconf upsert

### DIFF
--- a/rollCall/handlers/proxy.py
+++ b/rollCall/handlers/proxy.py
@@ -1,29 +1,64 @@
 """
 Proxy handlers: /set_in_for (/sif), /set_out_for (/sof), /set_maybe_for (/smf)
+
+Thin Telegram adapters over services/proxy.py:
+  1. Parse message (name, comment, ::N suffix)
+  2. Ghost reconfirmation check (Telegram inline-button UI)
+  3. Call proxy service
+  4. Format result → send Telegram messages
+  5. Update panel
 """
+import asyncio
 import logging
-
-from telebot.types import InlineKeyboardMarkup, InlineKeyboardButton
-
 from datetime import datetime
 
 from bot_state import (
-    bot, format_mention_with_name, format_mention_with_name_md, _esc_md,
-    _dm_promoted_real_user, _log_task_exc, get_rc_db_id,
-    _pending_proxy_add, _prune_pending, reply_error,
+    bot, _log_task_exc, _pending_proxy_add, _prune_pending,
+    format_mention_with_name_md, _esc_md,
+    _dm_promoted_real_user, reply_error,
 )
 from exceptions import (
     rollCallNotStarted, insufficientPermissions, parameterMissing, incorrectParameter,
-    duplicateProxy, repeatlyName,
 )
 from functions import admin_rights, roll_call_not_started
-from models import User
 from rollcall_manager import manager
-from db import (
-    add_or_update_proxy_user, log_admin_action, get_ghost_count_by_proxy_name,
-    increment_user_stat, increment_rollcall_stat,
-)
-import asyncio
+from services import proxy as proxy_svc
+from telebot.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+
+def _parse_proxy_args(text: str) -> tuple[int, str, str]:
+    """Return (rc_number_0based, proxy_name, comment)."""
+    parts = text.split()
+    rc_number = 0
+    if len(parts) > 1 and "::" in parts[-1]:
+        try:
+            rc_number = int(parts[-1].replace("::", "")) - 1
+            parts = parts[:-1]
+        except ValueError:
+            raise incorrectParameter("The rollcall number must be a positive integer")
+    if len(parts) < 2:
+        raise parameterMissing("Input username is missing")
+    proxy_name = parts[1]
+    comment = " ".join(parts[2:]) if len(parts) > 2 else ""
+    return rc_number, proxy_name, comment
+
+
+async def _send_promoted_proxy(cid: int, promoted: dict, rc_title: str, rc_number_1based: int):
+    """Announce and optionally DM a user promoted waitlist→IN via proxy command."""
+    if promoted["is_proxy"]:
+        if not manager.get_shh_mode(cid):
+            await bot.send_message(cid, f"{promoted['name']} → IN")
+    else:
+        if not manager.get_shh_mode(cid):
+            from models import User
+            u = User(promoted["name"], promoted.get("username"), promoted["user_id"], [])
+            await bot.send_message(
+                cid,
+                f"{format_mention_with_name_md(u)} → IN",
+                parse_mode="Markdown",
+            )
+        _t = asyncio.create_task(_dm_promoted_real_user(promoted["user_id"], rc_title, rc_number_1based))
+        _t.add_done_callback(_log_task_exc)
 
 
 @bot.message_handler(func=lambda message: (message.text.split(" "))[0].split("@")[0].lower() == "/set_in_for")
@@ -34,96 +69,49 @@ async def set_in_for(message):
             raise rollCallNotStarted("Roll call is not active")
         if await admin_rights(message, manager) == False:
             raise insufficientPermissions("Error - user does not have sufficient permissions for this operation")
-        if len(message.text.split(" ")) <= 1:
-            raise parameterMissing("Input username is missing")
 
-        msg = message.text
-        pmts = msg.split(" ")
         cid = message.chat.id
-        rc_number = 0
+        rc_number, proxy_name, comment = _parse_proxy_args(message.text)
 
-        if len(pmts) > 0 and "::" in pmts[-1]:
-            try:
-                rc_number = int(pmts[-1].replace("::", "")) - 1
-                del pmts[-1]
-                msg = " ".join(pmts)
-            except Exception:
-                raise incorrectParameter("The rollcall number must be a positive integer")
-
-        rollcalls = manager.get_rollcalls(cid)
-        if rc_number < 0 or len(rollcalls) < rc_number + 1:
-            raise incorrectParameter("The rollcall number doesn't exist, check /rollcalls to see all rollcalls")
-
-        rc = manager.get_rollcall(cid, rc_number)
-
-        arr = msg.split(" ")
-        if len(arr) > 1:
-            proxy_name = arr[1]
-
-            if len(proxy_name) > 40:
-                await bot.send_message(cid, f"⚠️ Proxy name is too long (max 40 characters). Got {len(proxy_name)}.")
-                return
-
-            already_present = any(
-                u.name == proxy_name and isinstance(u.user_id, str)
-                for u in rc.inList + rc.waitList
+        # Ghost reconfirmation for proxy (Telegram inline-button UI)
+        reconf = proxy_svc.check_proxy_ghost_reconfirmation_needed(cid, proxy_name)
+        if reconf["needed"]:
+            _prune_pending(_pending_proxy_add)
+            _pending_proxy_add[(cid, message.from_user.id, proxy_name)] = {
+                "comment": comment,
+                "_ts": datetime.now().timestamp(),
+            }
+            rc = manager.get_rollcall(cid, rc_number)
+            rc_title = rc.title if rc else ""
+            markup = InlineKeyboardMarkup(row_width=2)
+            markup.add(
+                InlineKeyboardButton("✅ Yes, add anyway", callback_data=f"proxy_add_{rc_number}_{proxy_name}"),
+                InlineKeyboardButton("❌ Cancel", callback_data=f"proxy_cancel_{rc_number}_{proxy_name}"),
             )
-            if already_present:
-                await bot.send_message(cid, f"⚠️ '{proxy_name}' is already IN or WAITING for '{rc.title}'.")
-                return
+            await bot.send_message(
+                cid,
+                f"👻 *Warning:* *{_esc_md(proxy_name)}* has ghosted *{reconf['ghost_count']}* session(s) before.\n"
+                f"⚠️ Absent Limit: *{reconf['absent_limit']}*\n\n"
+                f"Still add to *{_esc_md(rc_title)}*?",
+                parse_mode="Markdown",
+                reply_markup=markup,
+            )
+            return
 
-            user = User(proxy_name, None, proxy_name, rc.allNames)
-            comment = " ".join(arr[2:]) if len(arr) > 2 else ""
-            user.comment = comment
+        result = await proxy_svc.set_in_for(
+            cid, message.from_user.id, message.from_user.first_name,
+            proxy_name, comment, rc_number
+        )
 
-            ghost_count = get_ghost_count_by_proxy_name(cid, proxy_name)
-            if ghost_count > 0:
-                limit = manager.get_absent_limit(cid)
-                if ghost_count >= limit:
-                    _prune_pending(_pending_proxy_add)
-                    _pending_proxy_add[(cid, message.from_user.id, proxy_name)] = {
-                        'comment': comment,
-                        '_ts': datetime.now().timestamp(),
-                    }
-                    markup = InlineKeyboardMarkup(row_width=2)
-                    markup.add(
-                        InlineKeyboardButton("✅ Yes, add anyway", callback_data=f"proxy_add_{rc_number}_{proxy_name}"),
-                        InlineKeyboardButton("❌ Cancel", callback_data=f"proxy_cancel_{rc_number}_{proxy_name}"),
-                    )
-                    await bot.send_message(
-                        cid,
-                        f"👻 *Warning:* *{_esc_md(proxy_name)}* has ghosted *{ghost_count}* session(s) before.\n"
-                        f"⚠️ Absent Limit: *{limit}*\n\n"
-                        f"Still add to *{_esc_md(rc.title)}*?",
-                        parse_mode="Markdown",
-                        reply_markup=markup
-                    )
-                    return
+        if result["action"] == "waitlisted":
+            if not manager.get_shh_mode(cid):
+                await bot.send_message(cid, f"Event max limit is reached, {proxy_name} was added in waitlist")
+        elif result["action"] == "added":
+            if not manager.get_shh_mode(cid):
+                await bot.send_message(cid, f"{proxy_name} is now IN!")
 
-            proxy_owner_id = message.from_user.id
-            rc.set_proxy_owner(user.user_id, proxy_owner_id)
-
-            # rc.addIn → _save_user_to_db already writes the proxy row with
-            # the correct status (in or waitlist), so no separate
-            # add_or_update_proxy_user call is needed here.
-            result = rc.addIn(user)
-            rc.save()
-
-            log_admin_action(cid, message.from_user.id, message.from_user.first_name, "sif", target_name=proxy_name, rollcall_id=rc.id, details=rc.title)
-
-            if result == 'AB':
-                raise duplicateProxy("No duplicate proxy please :-), Thanks!")
-            elif result == 'AC':
-                if not manager.get_shh_mode(cid):
-                    await bot.send_message(cid, f"Event max limit is reached, {user.name} was added in waitlist")
-            elif result == 'AA':
-                raise repeatlyName("That name already exists!")
-            elif result is None:
-                if not manager.get_shh_mode(cid):
-                    await bot.send_message(cid, f"{user.name} is now IN!")
-
-            from handlers.lifecycle import show_panel_for_rollcall
-            await show_panel_for_rollcall(cid, rc_number + 1)
+        from handlers.lifecycle import show_panel_for_rollcall
+        await show_panel_for_rollcall(cid, result["rc_number_1based"])
 
     except Exception as e:
         await reply_error(message, e)
@@ -137,81 +125,37 @@ async def set_out_for(message):
             raise rollCallNotStarted("Roll call is not active")
         if await admin_rights(message, manager) == False:
             raise insufficientPermissions("Error - user does not have sufficient permissions for this operation")
-        if len(message.text.split(" ")) <= 1:
-            raise parameterMissing("Input username is missing")
 
-        msg = message.text
-        pmts = msg.split(" ")
         cid = message.chat.id
-        rc_number = 0
+        rc_number, proxy_name, comment = _parse_proxy_args(message.text)
 
-        if len(pmts) > 0 and "::" in pmts[-1]:
-            try:
-                rc_number = int(pmts[-1].replace("::", "")) - 1
-                del pmts[-1]
-                msg = " ".join(pmts)
-            except Exception:
-                raise incorrectParameter("The rollcall number must be a positive integer")
+        result = await proxy_svc.set_out_for(
+            cid, message.from_user.id, message.from_user.first_name,
+            proxy_name, comment, rc_number
+        )
 
-        rollcalls = manager.get_rollcalls(cid)
-        if rc_number < 0 or len(rollcalls) < rc_number + 1:
-            raise incorrectParameter("The rollcall number doesn't exist, check /rollcalls to see all rollcalls")
+        rc_title = result["rollcall"]["title"]
+        rc_number_1based = result["rc_number_1based"]
 
-        rc = manager.get_rollcall(cid, rc_number)
-        arr = msg.split(" ")
-
-        if len(arr) > 1:
-            user = User(arr[1], None, arr[1], rc.allNames)
-            comment = " ".join(arr[2:]) if len(arr) > 2 else ""
-            user.comment = comment
-
-            was_in = any((u.user_id == user.user_id or u.name == user.name) for u in rc.inList)
-
-            result = rc.addOut(user)
-            rc.save()
-
-            log_admin_action(cid, message.from_user.id, message.from_user.first_name, "sof", target_name=arr[1], rollcall_id=rc.id, details=rc.title)
-
-            if result == 'AB':
-                raise duplicateProxy("No duplicate proxy please :-), Thanks!")
-            elif result == 'AC':
-                if not manager.get_shh_mode(cid):
-                    await bot.send_message(cid, f"Event max limit is reached, {user.name} was added in waitlist")
-            elif result == 'AA':
-                raise repeatlyName("That name already exists!")
-            elif isinstance(result, User):
-                if not manager.get_shh_mode(cid):
-                    if isinstance(result.user_id, int):
-                        await bot.send_message(
-                            cid,
-                            f"{format_mention_with_name_md(result)} → IN",
-                            parse_mode="Markdown",
-                        )
-                    else:
-                        await bot.send_message(cid, f"{result.name} → IN")
-                if isinstance(result.user_id, int):
-                    asyncio.create_task(_dm_promoted_real_user(result.user_id, rc.title, rc_number + 1)).add_done_callback(_log_task_exc)
+        if result["promoted"]:
+            await _send_promoted_proxy(cid, result["promoted"], rc_title, rc_number_1based)
+            rc = manager.get_rollcall(cid, rc_number)
+            if rc:
                 from handlers.lifecycle import notify_proxy_owner_wait_to_in
-                await notify_proxy_owner_wait_to_in(rc, result, cid, rc.title, rc_number + 1)
-                # GLITCH FIX: voting.py /out and lifecycle.py panel-OUT both
-                # bump the promoted user's stats here. /sof was the only path
-                # missing it, so a real user promoted from waitlist via a
-                # proxy /sof would never see their total_in / total_in_promotion
-                # counter update. Now consistent.
-                rc_db_id = get_rc_db_id(rc)
-                if rc_db_id is not None and isinstance(result.user_id, int):
-                    increment_user_stat(cid, result.user_id, "total_waiting_to_in")
-                    increment_user_stat(cid, result.user_id, "total_in")
-                    increment_rollcall_stat(rc_db_id, "total_in")
-            elif result is None:
-                if not manager.get_shh_mode(cid):
-                    if was_in:
-                        await bot.send_message(cid, f"{user.name} → OUT for '{rc.title}' (#{rc_number + 1})")
-                    else:
-                        await bot.send_message(cid, f"{user.name} is now OUT!")
+                from models import User
+                promoted = result["promoted"]
+                promo_user = User(promoted["name"], promoted.get("username"),
+                                  promoted["user_id"], [])
+                await notify_proxy_owner_wait_to_in(rc, promo_user, cid, rc_title, rc_number_1based)
+        else:
+            if not manager.get_shh_mode(cid):
+                if result["was_in"]:
+                    await bot.send_message(cid, f"{proxy_name} → OUT for '{rc_title}' (#{rc_number_1based})")
+                else:
+                    await bot.send_message(cid, f"{proxy_name} is now OUT!")
 
-            from handlers.lifecycle import show_panel_for_rollcall
-            await show_panel_for_rollcall(cid, rc_number + 1)
+        from handlers.lifecycle import show_panel_for_rollcall
+        await show_panel_for_rollcall(cid, rc_number_1based)
 
     except Exception as e:
         await reply_error(message, e)
@@ -225,73 +169,34 @@ async def set_maybe_for(message):
             raise rollCallNotStarted("Roll call is not active")
         if await admin_rights(message, manager) == False:
             raise insufficientPermissions("Error - user does not have sufficient permissions for this operation")
-        if len(message.text.split(" ")) <= 1:
-            raise parameterMissing("Input username is missing")
 
-        msg = message.text
-        pmts = msg.split(" ")
         cid = message.chat.id
-        rc_number = 0
+        rc_number, proxy_name, comment = _parse_proxy_args(message.text)
 
-        if len(pmts) > 0 and "::" in pmts[-1]:
-            try:
-                rc_number = int(pmts[-1].replace("::", "")) - 1
-                del pmts[-1]
-                msg = " ".join(pmts)
-            except Exception:
-                raise incorrectParameter("The rollcall number must be a positive integer")
+        result = await proxy_svc.set_maybe_for(
+            cid, message.from_user.id, message.from_user.first_name,
+            proxy_name, comment, rc_number
+        )
 
-            rollcalls = manager.get_rollcalls(cid)
-            if rc_number < 0 or len(rollcalls) < rc_number + 1:
-                raise incorrectParameter("The rollcall number doesn't exist, check /rollcalls to see all rollcalls")
+        rc_title = result["rollcall"]["title"]
+        rc_number_1based = result["rc_number_1based"]
 
-        rc = manager.get_rollcall(cid, rc_number)
-        arr = msg.split(" ")
-
-        if len(arr) > 1:
-            user = User(arr[1], None, arr[1], rc.allNames)
-            comment = " ".join(arr[2:]) if len(arr) > 2 else ""
-            user.comment = comment
-
-            result = rc.addMaybe(user)
-            rc.save()
-
-            log_admin_action(cid, message.from_user.id, message.from_user.first_name, "smf", target_name=arr[1], rollcall_id=rc.id, details=rc.title)
-
-            if result == 'AB':
-                raise duplicateProxy("No duplicate proxy please :-), Thanks!")
-            elif result == 'AC':
-                if not manager.get_shh_mode(cid):
-                    await bot.send_message(cid, f"Event max limit is reached, {user.name} was added in waitlist")
-            elif result == 'AA':
-                raise repeatlyName("That name already exists!")
-            elif isinstance(result, User):
-                if not manager.get_shh_mode(cid):
-                    if isinstance(result.user_id, int):
-                        await bot.send_message(
-                            cid,
-                            f"{format_mention_with_name_md(result)} → IN (from WAITING) for '{_esc_md(rc.title)}' (#{rc_number + 1})",
-                            parse_mode="Markdown",
-                        )
-                    else:
-                        await bot.send_message(cid, f"{result.name} → IN (from WAITING) for '{rc.title}' (#{rc_number + 1})")
-                if isinstance(result.user_id, int):
-                    asyncio.create_task(_dm_promoted_real_user(result.user_id, rc.title, rc_number + 1)).add_done_callback(_log_task_exc)
+        if result["promoted"]:
+            await _send_promoted_proxy(cid, result["promoted"], rc_title, rc_number_1based)
+            rc = manager.get_rollcall(cid, rc_number)
+            if rc:
                 from handlers.lifecycle import notify_proxy_owner_wait_to_in
-                await notify_proxy_owner_wait_to_in(rc, result, cid, rc.title, rc_number + 1)
-                # GLITCH FIX: same as /sof above. /smf was also missing the
-                # promotion-counter bump for the real user moved waitlist→IN.
-                rc_db_id = get_rc_db_id(rc)
-                if rc_db_id is not None and isinstance(result.user_id, int):
-                    increment_user_stat(cid, result.user_id, "total_waiting_to_in")
-                    increment_user_stat(cid, result.user_id, "total_in")
-                    increment_rollcall_stat(rc_db_id, "total_in")
-            elif result is None:
-                if not manager.get_shh_mode(cid):
-                    await bot.send_message(cid, f"{user.name} is now MAYBE!")
+                from models import User
+                promoted = result["promoted"]
+                promo_user = User(promoted["name"], promoted.get("username"),
+                                  promoted["user_id"], [])
+                await notify_proxy_owner_wait_to_in(rc, promo_user, cid, rc_title, rc_number_1based)
+        else:
+            if not manager.get_shh_mode(cid):
+                await bot.send_message(cid, f"{proxy_name} is now MAYBE!")
 
-            from handlers.lifecycle import show_panel_for_rollcall
-            await show_panel_for_rollcall(cid, rc_number + 1)
+        from handlers.lifecycle import show_panel_for_rollcall
+        await show_panel_for_rollcall(cid, rc_number_1based)
 
     except Exception as e:
         await reply_error(message, e)

--- a/rollCall/handlers/voting.py
+++ b/rollCall/handlers/voting.py
@@ -1,5 +1,12 @@
 """
 Voting handlers: /in, /out, /maybe
+
+Each handler is now a thin Telegram adapter over services/voting.py:
+  1. Parse message text + ::N suffix
+  2. Ghost-reconfirmation check (Telegram-specific UI — inline buttons)
+  3. Call voting service (business logic lives there)
+  4. Format service result → send Telegram message
+  5. Update panel
 """
 import asyncio
 import logging
@@ -7,19 +14,48 @@ from datetime import datetime
 
 from bot_state import (
     bot, _log_task_exc, _pending_reconf, _is_rate_limited, _get_display_name,
-    format_mention_with_name, format_mention_with_name_md, _esc_md,
-    warn_no_username, _dm_promoted_real_user, get_rc_db_id, reply_error,
+    format_mention_with_name_md, _esc_md,
+    warn_no_username, _dm_promoted_real_user, reply_error,
 )
-from exceptions import (
-    rollCallNotStarted, incorrectParameter, alreadyInList,
-)
+from exceptions import rollCallNotStarted, incorrectParameter, alreadyInList
 from functions import roll_call_not_started
-from models import User
 from rollcall_manager import manager
-from db import (
-    increment_user_stat, increment_rollcall_stat, get_ghost_count, upsert_chat_member,
-)
+from services import voting as vote_svc
 from telebot.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+
+def _parse_rc_and_comment(text: str) -> tuple[int, str]:
+    """Return (rc_number_0based, comment) from a command text like '/in hi ::2'."""
+    parts = text.split()
+    rc_number = 0
+    if parts and "::" in parts[-1]:
+        try:
+            rc_number = int(parts[-1].replace("::", "")) - 1
+            parts = parts[:-1]
+        except ValueError:
+            raise incorrectParameter("The rollcall number must be a positive integer")
+    comment = " ".join(parts[1:]) if len(parts) > 1 else ""
+    return rc_number, comment
+
+
+async def _send_promoted(cid: int, promoted: dict, rc_title: str, rc_number_1based: int):
+    """Announce a waitlist promotion and optionally DM the promoted user."""
+    if promoted["is_proxy"]:
+        if not manager.get_shh_mode(cid):
+            await bot.send_message(
+                cid, f"{promoted['name']} → IN (from WAITING) for '{rc_title}' (#{rc_number_1based})"
+            )
+    else:
+        if not manager.get_shh_mode(cid):
+            from models import User
+            u = User(promoted["name"], promoted.get("username"), promoted["user_id"], [])
+            await bot.send_message(
+                cid,
+                f"{format_mention_with_name_md(u)} → IN (from WAITING) for '{_esc_md(rc_title)}' (#{rc_number_1based})",
+                parse_mode="Markdown",
+            )
+        _t = asyncio.create_task(_dm_promoted_real_user(promoted["user_id"], rc_title, rc_number_1based))
+        _t.add_done_callback(_log_task_exc)
 
 
 @bot.message_handler(func=lambda message: (message.text.split(" "))[0].split("@")[0].lower() == "/in")
@@ -29,102 +65,68 @@ async def in_user(message):
             raise rollCallNotStarted("Roll call is not active")
         if _is_rate_limited(message.chat.id, message.from_user.id):
             return
-        msg = message.text
-        pmts = msg.split(" ")
+
         cid = message.chat.id
-        comment = ""
-        rc_number = 0
+        rc_number, comment = _parse_rc_and_comment(message.text)
+        user_id = message.from_user.id
+        display_name = _get_display_name(message.from_user)
+        username = message.from_user.username or None
 
-        if len(pmts) > 0 and "::" in pmts[-1]:
-            try:
-                rc_number = int(pmts[-1].replace("::", "")) - 1
-                del pmts[-1]
-                msg = " ".join(pmts)
-            except Exception:
-                raise incorrectParameter("The rollcall number must be a positive integer")
+        if not username:
+            asyncio.create_task(warn_no_username(cid, display_name)).add_done_callback(_log_task_exc)
 
-        rollcalls = manager.get_rollcalls(cid)
-        if rc_number < 0 or len(rollcalls) < rc_number + 1:
-            raise incorrectParameter("The rollcall number doesn't exist, check /rollcalls to see all rollcalls")
+        from db import upsert_chat_member as _upsert
+        _upsert(cid, user_id, display_name, username)
 
-        rc = manager.get_rollcall(cid, rc_number)
-        _username = message.from_user.username or None
-        _display_name = _get_display_name(message.from_user)
-        if not _username:
-            asyncio.create_task(warn_no_username(cid, _display_name)).add_done_callback(_log_task_exc)
-        user = User(_display_name, _username, message.from_user.id, rc.allNames)
+        # Ghost reconfirmation (Telegram-specific UI — inline buttons)
+        reconf = vote_svc.check_ghost_reconfirmation_needed(cid, user_id, rc_number)
+        if reconf["needed"]:
+            if (cid, user_id) in _pending_reconf:
+                return
+            _pending_reconf[(cid, user_id)] = {
+                "rc_number": rc_number,
+                "comment": comment,
+                "_ts": datetime.now().timestamp(),
+            }
+            rc_title = reconf["rollcall_title"]
+            markup = InlineKeyboardMarkup(row_width=2)
+            markup.add(
+                InlineKeyboardButton("✅ Yes, I'll be there!", callback_data=f"reconf_in_{rc_number}_{user_id}"),
+                InlineKeyboardButton("❌ I'm out", callback_data=f"reconf_out_{rc_number}_{user_id}"),
+            )
+            await bot.send_message(
+                cid,
+                f"👻 *Warning:* [​](tg://user?id={user_id}){_esc_md(display_name)}, "
+                f"you've ghosted *{reconf['ghost_count']}* session(s) before.\n"
+                f"⚠️ Absent Limit: *{reconf['absent_limit']}*\n\n"
+                f"Are you committing to be at *{_esc_md(rc_title)}*?",
+                parse_mode="Markdown",
+                reply_markup=markup,
+            )
+            return
 
-        arr = msg.split(" ")
-        if len(arr) > 1:
-            arr.pop(0)
-            comment = ' '.join(arr)
-        user.comment = comment
+        # Business logic via service
+        result = await vote_svc.vote_in(cid, user_id, display_name, username, comment, rc_number)
 
-        if isinstance(user.user_id, int):
-            upsert_chat_member(cid, user.user_id, _display_name, _username)
-
-        if isinstance(user.user_id, int) and manager.get_ghost_tracking_enabled(cid):
-            ghost_count = get_ghost_count(cid, user.user_id)
-            absent_limit = manager.get_absent_limit(cid)
-            already_in = any(u.user_id == user.user_id for u in rc.inList)
-            if ghost_count >= absent_limit and not already_in:
-                # Don't stack prompts — if one is already open, the buttons on
-                # the existing message are still valid; silently ignore the
-                # repeat /in instead of spamming a second warning.
-                if (cid, user.user_id) in _pending_reconf:
-                    return
-                _pending_reconf[(cid, user.user_id)] = {
-                    'rc_number': rc_number,
-                    'comment': comment,
-                    '_ts': datetime.now().timestamp(),
-                }
-                markup = InlineKeyboardMarkup(row_width=2)
-                markup.add(
-                    InlineKeyboardButton("✅ Yes, I'll be there!", callback_data=f"reconf_in_{rc_number}_{user.user_id}"),
-                    InlineKeyboardButton("❌ I'm out", callback_data=f"reconf_out_{rc_number}_{user.user_id}"),
-                )
+        # Format response
+        if result["action"] == "waitlisted":
+            if not manager.get_shh_mode(cid):
+                await bot.send_message(cid, f"Event max limit is reached, {display_name} was added in waitlist")
+        elif result["action"] == "added":
+            if not manager.get_shh_mode(cid):
+                from models import User
+                u = User(display_name, username, user_id, [])
                 await bot.send_message(
                     cid,
-                    f"👻 *Warning:* {format_mention_with_name_md(user)}, you've ghosted *{ghost_count}* session(s) before.\n"
-                    f"⚠️ Absent Limit: *{absent_limit}*\n\n"
-                    f"Are you committing to be at *{_esc_md(rc.title)}*?",
+                    f"{format_mention_with_name_md(u)} is now IN!",
                     parse_mode="Markdown",
-                    reply_markup=markup
                 )
-                return
 
-        async with manager.get_chat_write_lock(cid):
-            # Re-fetch rc inside the lock — /erc could have removed it.
-            rc = manager.get_rollcall(cid, rc_number)
-            if rc is None:
-                raise rollCallNotStarted("Roll call is not active")
-
-            result = rc.addIn(user)
-            rc.save()
-
-            rc_db_id = get_rc_db_id(rc)
-            if result not in ('AB', 'AC', 'AU') and rc_db_id is not None and isinstance(user.user_id, int):
-                increment_user_stat(cid, user.user_id, "total_in")
-                increment_rollcall_stat(rc_db_id, "total_in")
-
-            if result == 'AB':
-                raise alreadyInList(f"{user.name}, you're already IN for '{rc.title}'.")
-            elif result == 'AC':
-                if not manager.get_shh_mode(cid):
-                    await bot.send_message(cid, f"Event max limit is reached, {user.name} was added in waitlist")
-            elif result is None:
-                if not manager.get_shh_mode(cid):
-                    if isinstance(user.user_id, int):
-                        await bot.send_message(
-                            cid,
-                            f"{format_mention_with_name_md(user)} is now IN!",
-                            parse_mode="Markdown",
-                        )
-                    else:
-                        await bot.send_message(cid, f"{user.name} is now IN!")
-
-            from handlers.lifecycle import _update_panel
-            await _update_panel(cid, rc_number + 1, rc)
+        from handlers.lifecycle import _update_panel
+        rc_number_1based = result["rc_number_1based"]
+        rc = manager.get_rollcall(cid, rc_number)
+        if rc:
+            await _update_panel(cid, rc_number_1based, rc)
 
     except Exception as e:
         await reply_error(message, e)
@@ -137,103 +139,54 @@ async def out_user(message):
             raise rollCallNotStarted("Roll call is not active")
         if _is_rate_limited(message.chat.id, message.from_user.id):
             return
-        msg = message.text
-        pmts = msg.split(" ")
+
         cid = message.chat.id
-        comment = ""
-        rc_number = 0
+        rc_number, comment = _parse_rc_and_comment(message.text)
+        user_id = message.from_user.id
+        display_name = _get_display_name(message.from_user)
+        username = message.from_user.username or None
 
-        if len(pmts) > 0 and "::" in pmts[-1]:
-            try:
-                rc_number = int(pmts[-1].replace("::", "")) - 1
-                del pmts[-1]
-                msg = " ".join(pmts)
-            except Exception:
-                raise incorrectParameter("The rollcall number must be a positive integer")
+        if not username:
+            asyncio.create_task(warn_no_username(cid, display_name)).add_done_callback(_log_task_exc)
 
-        rollcalls = manager.get_rollcalls(cid)
-        if rc_number < 0 or len(rollcalls) < rc_number + 1:
-            raise incorrectParameter("The rollcall number doesn't exist, check /rollcalls to see all rollcalls")
+        result = await vote_svc.vote_out(cid, user_id, display_name, username, comment, rc_number)
 
-        rc = manager.get_rollcall(cid, rc_number)
-        _username = message.from_user.username or None
-        _display_name = _get_display_name(message.from_user)
-        if not _username:
-            asyncio.create_task(warn_no_username(cid, _display_name)).add_done_callback(_log_task_exc)
-        user = User(_display_name, _username, message.from_user.id, rc.allNames)
+        rc_title = result["rollcall"]["title"]
+        rc_number_1based = result["rc_number_1based"]
 
-        arr = msg.split(" ")
-        if len(arr) > 1:
-            arr.pop(0)
-            comment = ' '.join(arr)
-        user.comment = comment
-
-        if isinstance(user.user_id, int):
-            upsert_chat_member(cid, user.user_id, _display_name, _username)
-
-        async with manager.get_chat_write_lock(cid):
+        # Announce promotion if someone moved waitlist→IN
+        if result["promoted"]:
+            await _send_promoted(cid, result["promoted"], rc_title, rc_number_1based)
+            # Notify proxy owner if promoted user is a proxy
             rc = manager.get_rollcall(cid, rc_number)
-            if rc is None:
-                raise rollCallNotStarted("Roll call is not active")
-
-            was_in = any(u.user_id == user.user_id for u in rc.inList)
-
-            result = rc.addOut(user)
-            rc.save()
-
-            rc_db_id = get_rc_db_id(rc)
-            if result not in ('AB', 'AU') and rc_db_id is not None and isinstance(user.user_id, int):
-                increment_user_stat(cid, user.user_id, "total_out")
-                increment_rollcall_stat(rc_db_id, "total_out")
-
-            if result == 'AB':
-                raise alreadyInList(f"{user.name}, you're already OUT for '{rc.title}'.")
-            elif isinstance(result, User):
-                if not manager.get_shh_mode(cid):
-                    if isinstance(result.user_id, int):
-                        await bot.send_message(
-                            cid,
-                            f"{format_mention_with_name_md(result)} → IN",
-                            parse_mode="Markdown",
-                        )
-                    else:
-                        await bot.send_message(cid, f"{result.name} → IN")
-
-                if isinstance(result.user_id, int):
-                    asyncio.create_task(_dm_promoted_real_user(result.user_id, rc.title, rc_number + 1)).add_done_callback(_log_task_exc)
-
+            if rc:
                 from handlers.lifecycle import notify_proxy_owner_wait_to_in
-                await notify_proxy_owner_wait_to_in(rc, result, cid, rc.title, rc_number + 1)
+                from models import User
+                promoted = result["promoted"]
+                promo_user = User(promoted["name"], promoted.get("username"),
+                                  promoted["user_id"], [])
+                await notify_proxy_owner_wait_to_in(rc, promo_user, cid, rc_title, rc_number_1based)
+        else:
+            if not manager.get_shh_mode(cid) and result["action"] != "already":
+                from models import User
+                u = User(display_name, username, user_id, [])
+                if result["was_in"]:
+                    await bot.send_message(
+                        cid,
+                        f"{format_mention_with_name_md(u)} → OUT for '{_esc_md(rc_title)}' (#{rc_number_1based})",
+                        parse_mode="Markdown",
+                    )
+                else:
+                    await bot.send_message(
+                        cid,
+                        f"{format_mention_with_name_md(u)} is now OUT!",
+                        parse_mode="Markdown",
+                    )
 
-                if rc_db_id is not None and isinstance(result.user_id, int):
-                    increment_user_stat(cid, result.user_id, "total_waiting_to_in")
-                    increment_user_stat(cid, result.user_id, "total_in")
-                    increment_rollcall_stat(rc_db_id, "total_in")
-
-            if not manager.get_shh_mode(cid) and result not in ('AB', 'AU') and not isinstance(result, User):
-                in_outlist_now = any(u.user_id == user.user_id for u in rc.outList)
-                if in_outlist_now:
-                    if isinstance(user.user_id, int):
-                        if was_in:
-                            await bot.send_message(
-                                cid,
-                                f"{format_mention_with_name_md(user)} → OUT for '{_esc_md(rc.title)}' (#{rc_number + 1})",
-                                parse_mode="Markdown",
-                            )
-                        else:
-                            await bot.send_message(
-                                cid,
-                                f"{format_mention_with_name_md(user)} is now OUT!",
-                                parse_mode="Markdown",
-                            )
-                    else:
-                        if was_in:
-                            await bot.send_message(cid, f"{user.name} → OUT for '{rc.title}' (#{rc_number + 1})")
-                        else:
-                            await bot.send_message(cid, f"{user.name} is now OUT!")
-
-            from handlers.lifecycle import _update_panel
-            await _update_panel(cid, rc_number + 1, rc)
+        from handlers.lifecycle import _update_panel
+        rc = manager.get_rollcall(cid, rc_number)
+        if rc:
+            await _update_panel(cid, rc_number_1based, rc)
 
     except Exception as e:
         await reply_error(message, e)
@@ -246,90 +199,45 @@ async def maybe_user(message):
             raise rollCallNotStarted("Roll call is not active")
         if _is_rate_limited(message.chat.id, message.from_user.id):
             return
-        msg = message.text
-        pmts = msg.split(" ")
+
         cid = message.chat.id
-        comment = ""
-        rc_number = 0
+        rc_number, comment = _parse_rc_and_comment(message.text)
+        user_id = message.from_user.id
+        display_name = _get_display_name(message.from_user)
+        username = message.from_user.username or None
 
-        if len(pmts) > 0 and "::" in pmts[-1]:
-            try:
-                rc_number = int(pmts[-1].replace("::", "")) - 1
-                del pmts[-1]
-                msg = " ".join(pmts)
-            except Exception:
-                raise incorrectParameter("The rollcall number must be a positive integer")
+        if not username:
+            asyncio.create_task(warn_no_username(cid, display_name)).add_done_callback(_log_task_exc)
 
-        rollcalls = manager.get_rollcalls(cid)
-        if rc_number < 0 or len(rollcalls) < rc_number + 1:
-            raise incorrectParameter("The rollcall number doesn't exist, check /rollcalls to see all rollcalls")
+        result = await vote_svc.vote_maybe(cid, user_id, display_name, username, comment, rc_number)
 
-        rc = manager.get_rollcall(cid, rc_number)
-        _username = message.from_user.username or None
-        _display_name = _get_display_name(message.from_user)
-        if not _username:
-            asyncio.create_task(warn_no_username(cid, _display_name)).add_done_callback(_log_task_exc)
-        user = User(_display_name, _username, message.from_user.id, rc.allNames)
+        rc_title = result["rollcall"]["title"]
+        rc_number_1based = result["rc_number_1based"]
 
-        arr = msg.split(" ")
-        if len(arr) > 1:
-            arr.pop(0)
-            comment = ' '.join(arr)
-        user.comment = comment
-
-        if isinstance(user.user_id, int):
-            upsert_chat_member(cid, user.user_id, _display_name, _username)
-
-        async with manager.get_chat_write_lock(cid):
+        if result["promoted"]:
+            await _send_promoted(cid, result["promoted"], rc_title, rc_number_1based)
             rc = manager.get_rollcall(cid, rc_number)
-            if rc is None:
-                raise rollCallNotStarted("Roll call is not active")
-
-            result = rc.addMaybe(user)
-            rc.save()
-
-            rc_db_id = get_rc_db_id(rc)
-            if result not in ('AB', 'AU') and rc_db_id is not None and isinstance(user.user_id, int):
-                increment_user_stat(cid, user.user_id, "total_maybe")
-                increment_rollcall_stat(rc_db_id, "total_maybe")
-
-            if result == 'AB':
-                raise alreadyInList(f"{user.name}, you're already MAYBE for '{rc.title}'.")
-            elif isinstance(result, User):
-                if not manager.get_shh_mode(cid):
-                    if isinstance(result.user_id, int):
-                        await bot.send_message(
-                            cid,
-                            f"{format_mention_with_name_md(result)} → IN (from WAITING) for '{_esc_md(rc.title)}' (#{rc_number + 1})",
-                            parse_mode="Markdown",
-                        )
-                    else:
-                        await bot.send_message(cid, f"{result.name} → IN (from WAITING) for '{rc.title}' (#{rc_number + 1})")
-
-                if isinstance(result.user_id, int):
-                    asyncio.create_task(_dm_promoted_real_user(result.user_id, rc.title, rc_number + 1)).add_done_callback(_log_task_exc)
-
+            if rc:
                 from handlers.lifecycle import notify_proxy_owner_wait_to_in
-                await notify_proxy_owner_wait_to_in(rc, result, cid, rc.title, rc_number + 1)
+                from models import User
+                promoted = result["promoted"]
+                promo_user = User(promoted["name"], promoted.get("username"),
+                                  promoted["user_id"], [])
+                await notify_proxy_owner_wait_to_in(rc, promo_user, cid, rc_title, rc_number_1based)
+        else:
+            if not manager.get_shh_mode(cid):
+                from models import User
+                u = User(display_name, username, user_id, [])
+                await bot.send_message(
+                    cid,
+                    f"{format_mention_with_name_md(u)} is now MAYBE!",
+                    parse_mode="Markdown",
+                )
 
-                if rc_db_id is not None and isinstance(result.user_id, int):
-                    increment_user_stat(cid, result.user_id, "total_waiting_to_in")
-                    increment_user_stat(cid, result.user_id, "total_in")
-                    increment_rollcall_stat(rc_db_id, "total_in")
-
-            elif result is None:
-                if not manager.get_shh_mode(cid):
-                    if isinstance(user.user_id, int):
-                        await bot.send_message(
-                            cid,
-                            f"{format_mention_with_name_md(user)} is now MAYBE!",
-                            parse_mode="Markdown",
-                        )
-                    else:
-                        await bot.send_message(cid, f"{user.name} is now MAYBE!")
-
-            from handlers.lifecycle import _update_panel
-            await _update_panel(cid, rc_number + 1, rc)
+        from handlers.lifecycle import _update_panel
+        rc = manager.get_rollcall(cid, rc_number)
+        if rc:
+            await _update_panel(cid, rc_number_1based, rc)
 
     except Exception as e:
         await reply_error(message, e)

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -935,8 +935,10 @@ class TestSifDuplicateProxyGuard(unittest.IsolatedAsyncioTestCase):
         m.get_absent_limit.return_value = 1
 
         with patch('handlers.proxy.manager', m), \
+             patch('rollcall_manager.manager', m), \
+             patch('services.proxy.manager', m), \
              patch('handlers.proxy.admin_rights', new=AsyncMock(return_value=True)), \
-             patch('handlers.proxy.get_ghost_count_by_proxy_name', return_value=0):
+             patch('services.proxy.get_ghost_count_by_proxy_name', return_value=0):
             msg = self._make_message("/sif Charlie")
             await self.set_in_for(msg)
 
@@ -965,8 +967,10 @@ class TestSifDuplicateProxyGuard(unittest.IsolatedAsyncioTestCase):
         m.get_absent_limit.return_value = 1
 
         with patch('handlers.proxy.manager', m), \
+             patch('rollcall_manager.manager', m), \
+             patch('services.proxy.manager', m), \
              patch('handlers.proxy.admin_rights', new=AsyncMock(return_value=True)), \
-             patch('handlers.proxy.get_ghost_count_by_proxy_name', return_value=0):
+             patch('services.proxy.get_ghost_count_by_proxy_name', return_value=0):
             msg = self._make_message("/sif Dave")
             await self.set_in_for(msg)
 
@@ -997,8 +1001,11 @@ class TestSifDuplicateProxyGuard(unittest.IsolatedAsyncioTestCase):
         m.get_absent_limit.return_value = 1
 
         with patch('handlers.proxy.manager', m), \
+             patch('rollcall_manager.manager', m), \
+             patch('services.proxy.manager', m), \
              patch('handlers.proxy.admin_rights', new=AsyncMock(return_value=True)), \
-             patch('handlers.proxy.get_ghost_count_by_proxy_name', return_value=0):
+             patch('services.proxy.get_ghost_count_by_proxy_name', return_value=0), \
+             patch('handlers.lifecycle.show_panel_for_rollcall', new=AsyncMock()):
             msg = self._make_message("/sif Eve")
             await self.set_in_for(msg)
 

--- a/tests/test_ghost_tracking.py
+++ b/tests/test_ghost_tracking.py
@@ -265,9 +265,9 @@ class TestInReconfirmation(GhostTestBase):
     async def test_reconfirmation_sent_when_ghost_count_at_limit(self):
         with self._rc_started_voting(), \
              patch('handlers.voting.manager', self.manager), \
-             patch('handlers.voting.get_ghost_count', return_value=1), \
-             patch('handlers.voting.asyncio') as mock_asyncio:
-            mock_asyncio.create_task = MagicMock()
+             patch('rollcall_manager.manager', self.manager), \
+             patch('services.voting.manager', self.manager), \
+             patch('services.voting.get_ghost_count', return_value=1):
             await self.in_user(self._make_message("/in"))
 
         self.assertEqual(self._sent_count(), 1)
@@ -278,12 +278,10 @@ class TestInReconfirmation(GhostTestBase):
     async def test_no_reconfirmation_when_ghost_count_below_limit(self):
         with self._rc_started_voting(), \
              patch('handlers.voting.manager', self.manager), \
-             patch('handlers.voting.get_ghost_count', return_value=0), \
-             patch('handlers.voting.get_rc_db_id', return_value=1), \
-             patch('handlers.voting.increment_user_stat'), \
-             patch('handlers.voting.increment_rollcall_stat'), \
-             patch('handlers.voting.asyncio') as mock_asyncio:
-            mock_asyncio.create_task = MagicMock()
+             patch('rollcall_manager.manager', self.manager), \
+             patch('services.voting.manager', self.manager), \
+             patch('services.voting.get_ghost_count', return_value=0), \
+             patch('handlers.lifecycle._update_panel', return_value=False):
             await self.in_user(self._make_message("/in"))
 
         # Should proceed normally — rc.addIn was called
@@ -294,12 +292,9 @@ class TestInReconfirmation(GhostTestBase):
 
         with self._rc_started_voting(), \
              patch('handlers.voting.manager', self.manager), \
-             patch('handlers.voting.get_ghost_count', return_value=5), \
-             patch('handlers.voting.get_rc_db_id', return_value=1), \
-             patch('handlers.voting.increment_user_stat'), \
-             patch('handlers.voting.increment_rollcall_stat'), \
-             patch('handlers.voting.asyncio') as mock_asyncio:
-            mock_asyncio.create_task = MagicMock()
+             patch('rollcall_manager.manager', self.manager), \
+             patch('services.voting.manager', self.manager), \
+             patch('handlers.lifecycle._update_panel', return_value=False):
             await self.in_user(self._make_message("/in"))
 
         self.rc.addIn.assert_called_once()
@@ -307,9 +302,9 @@ class TestInReconfirmation(GhostTestBase):
     async def test_pending_reconf_stored(self):
         with self._rc_started_voting(), \
              patch('handlers.voting.manager', self.manager), \
-             patch('handlers.voting.get_ghost_count', return_value=2), \
-             patch('handlers.voting.asyncio') as mock_asyncio:
-            mock_asyncio.create_task = MagicMock()
+             patch('rollcall_manager.manager', self.manager), \
+             patch('services.voting.manager', self.manager), \
+             patch('services.voting.get_ghost_count', return_value=2):
             await self.in_user(self._make_message("/in hello", user_id=1))
 
         self.assertIn((100, 1), self.bot_state._pending_reconf)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -246,6 +246,9 @@ class HandlerTestBase(unittest.IsolatedAsyncioTestCase):
             patch('handlers.core.manager', self.manager),
             patch('handlers.templates.manager', self.manager),
             patch('handlers.stats.manager', self.manager),
+            patch('rollcall_manager.manager', self.manager),
+            patch('services.voting.manager', self.manager),
+            patch('services.proxy.manager', self.manager),
         ])
 
 
@@ -510,10 +513,7 @@ class TestInUser(HandlerTestBase):
         self.rc.addIn.return_value = None
         msg = self._make_message("/in")
         with self._rc_started(), self._patch_manager(), \
-             patch('handlers.lifecycle._update_panel', return_value=False), \
-             patch('handlers.voting.increment_user_stat'), \
-             patch('handlers.voting.increment_rollcall_stat'), \
-             patch('handlers.voting.get_rc_db_id', return_value=1):
+             patch('handlers.lifecycle._update_panel', return_value=False):
             await self.in_user(msg)
         self.rc.addIn.assert_called_once()
 
@@ -527,10 +527,7 @@ class TestInUser(HandlerTestBase):
         self.rc.addIn.return_value = None
         msg = self._make_message("/in running late")
         with self._rc_started(), self._patch_manager(), \
-             patch('handlers.lifecycle._update_panel', return_value=False), \
-             patch('handlers.voting.increment_user_stat'), \
-             patch('handlers.voting.increment_rollcall_stat'), \
-             patch('handlers.voting.get_rc_db_id', return_value=1):
+             patch('handlers.lifecycle._update_panel', return_value=False):
             await self.in_user(msg)
         # User object should have comment set
         self.rc.addIn.assert_called_once()
@@ -539,10 +536,7 @@ class TestInUser(HandlerTestBase):
         self.rc.addIn.return_value = 'AB'
         msg = self._make_message("/in")
         with self._rc_started(), self._patch_manager(), \
-             patch('handlers.lifecycle._update_panel', return_value=False), \
-             patch('handlers.voting.increment_user_stat'), \
-             patch('handlers.voting.increment_rollcall_stat'), \
-             patch('handlers.voting.get_rc_db_id', return_value=1):
+             patch('handlers.lifecycle._update_panel', return_value=False):
             await self.in_user(msg)
         self.assertGreater(self._sent_count(), 0)
 
@@ -550,10 +544,7 @@ class TestInUser(HandlerTestBase):
         self.rc.addIn.return_value = 'AC'
         msg = self._make_message("/in")
         with self._rc_started(), self._patch_manager(), \
-             patch('handlers.lifecycle._update_panel', return_value=False), \
-             patch('handlers.voting.increment_user_stat'), \
-             patch('handlers.voting.increment_rollcall_stat'), \
-             patch('handlers.voting.get_rc_db_id', return_value=1):
+             patch('handlers.lifecycle._update_panel', return_value=False):
             await self.in_user(msg)
         sent = self._sent_text()
         self.assertIn("waitlist", sent.lower())
@@ -564,10 +555,9 @@ class TestInUser(HandlerTestBase):
         multi_manager.get_rollcall.return_value = rc2
         msg = self._make_message("/in ::2")
         with self._rc_started(), patch('handlers.voting.manager', multi_manager), \
-             patch('handlers.lifecycle._update_panel', return_value=False), \
-             patch('handlers.voting.increment_user_stat'), \
-             patch('handlers.voting.increment_rollcall_stat'), \
-             patch('handlers.voting.get_rc_db_id', return_value=2):
+             patch('rollcall_manager.manager', multi_manager), \
+             patch('services.voting.manager', multi_manager), \
+             patch('handlers.lifecycle._update_panel', return_value=False):
             await self.in_user(msg)
         multi_manager.get_rollcall.assert_called_with(100, 1)  # index 1 = RC #2
 
@@ -589,9 +579,6 @@ class TestOutUser(HandlerTestBase):
         msg = self._make_message("/out")
         with self._rc_started(), self._patch_manager(), \
              patch('handlers.lifecycle._update_panel', return_value=False), \
-             patch('handlers.voting.increment_user_stat'), \
-             patch('handlers.voting.increment_rollcall_stat'), \
-             patch('handlers.voting.get_rc_db_id', return_value=1), \
              patch('handlers.lifecycle.notify_proxy_owner_wait_to_in', new=AsyncMock()):
             await self.out_user(msg)
         self.rc.addOut.assert_called_once()
@@ -607,9 +594,6 @@ class TestOutUser(HandlerTestBase):
         msg = self._make_message("/out")
         with self._rc_started(), self._patch_manager(), \
              patch('handlers.lifecycle._update_panel', return_value=False), \
-             patch('handlers.voting.increment_user_stat'), \
-             patch('handlers.voting.increment_rollcall_stat'), \
-             patch('handlers.voting.get_rc_db_id', return_value=1), \
              patch('handlers.lifecycle.notify_proxy_owner_wait_to_in', new=AsyncMock()):
             await self.out_user(msg)
         self.assertGreater(self._sent_count(), 0)
@@ -621,11 +605,7 @@ class TestOutUser(HandlerTestBase):
         msg = self._make_message("/out")
         with self._rc_started(), self._patch_manager(), \
              patch('handlers.lifecycle._update_panel', return_value=False), \
-             patch('handlers.voting.increment_user_stat'), \
-             patch('handlers.voting.increment_rollcall_stat'), \
-             patch('handlers.voting.get_rc_db_id', return_value=1), \
-             patch('handlers.lifecycle.notify_proxy_owner_wait_to_in', new=AsyncMock()), \
-             patch('handlers.voting.format_mention_with_name', return_value="Dave"):
+             patch('handlers.lifecycle.notify_proxy_owner_wait_to_in', new=AsyncMock()):
             await self.out_user(msg)
         # A "→ IN" message must have been sent for the promoted user
         texts = [c[0][1] for c in self.bot_state.bot.send_message.call_args_list]
@@ -642,10 +622,7 @@ class TestMaybeUser(HandlerTestBase):
         self.rc.addMaybe.return_value = None
         msg = self._make_message("/maybe")
         with self._rc_started(), self._patch_manager(), \
-             patch('handlers.lifecycle._update_panel', return_value=False), \
-             patch('handlers.voting.increment_user_stat'), \
-             patch('handlers.voting.increment_rollcall_stat'), \
-             patch('handlers.voting.get_rc_db_id', return_value=1):
+             patch('handlers.lifecycle._update_panel', return_value=False):
             await self.maybe_user(msg)
         self.rc.addMaybe.assert_called_once()
 
@@ -659,10 +636,7 @@ class TestMaybeUser(HandlerTestBase):
         self.rc.addMaybe.return_value = 'AB'
         msg = self._make_message("/maybe")
         with self._rc_started(), self._patch_manager(), \
-             patch('handlers.lifecycle._update_panel', return_value=False), \
-             patch('handlers.voting.increment_user_stat'), \
-             patch('handlers.voting.increment_rollcall_stat'), \
-             patch('handlers.voting.get_rc_db_id', return_value=1):
+             patch('handlers.lifecycle._update_panel', return_value=False):
             await self.maybe_user(msg)
         self.assertGreater(self._sent_count(), 0)
 
@@ -676,8 +650,7 @@ class TestSetInFor(HandlerTestBase):
     async def test_proxy_in_happy_path(self):
         self.rc.addIn.return_value = None
         msg = self._make_message("/set_in_for Bob")
-        with self._rc_started(), self._patch_manager(), self._panel(), \
-             patch('handlers.proxy.add_or_update_proxy_user'):
+        with self._rc_started(), self._patch_manager(), self._panel():
             await self.set_in_for(msg)
         self.rc.addIn.assert_called_once()
 
@@ -696,16 +669,14 @@ class TestSetInFor(HandlerTestBase):
     async def test_proxy_in_duplicate_sends_error(self):
         self.rc.addIn.return_value = 'AB'
         msg = self._make_message("/set_in_for Bob")
-        with self._rc_started(), self._patch_manager(), self._panel(), \
-             patch('handlers.proxy.add_or_update_proxy_user'):
+        with self._rc_started(), self._patch_manager(), self._panel():
             await self.set_in_for(msg)
         self.assertGreater(self._sent_count(), 0)
 
     async def test_proxy_in_waitlist_sends_message(self):
         self.rc.addIn.return_value = 'AC'
         msg = self._make_message("/set_in_for Bob")
-        with self._rc_started(), self._patch_manager(), self._panel(), \
-             patch('handlers.proxy.add_or_update_proxy_user'):
+        with self._rc_started(), self._patch_manager(), self._panel():
             await self.set_in_for(msg)
         sent = self._sent_text()
         self.assertIn("waitlist", sent.lower())
@@ -721,7 +692,6 @@ class TestSetOutFor(HandlerTestBase):
         self.rc.addOut.return_value = None
         msg = self._make_message("/set_out_for Bob")
         with self._rc_started(), self._patch_manager(), self._panel(), \
-             patch('handlers.proxy.add_or_update_proxy_user'), \
              patch('handlers.lifecycle.notify_proxy_owner_wait_to_in', new=AsyncMock()):
             await self.set_out_for(msg)
         self.rc.addOut.assert_called_once()
@@ -748,8 +718,7 @@ class TestSetMaybeFor(HandlerTestBase):
     async def test_proxy_maybe_happy_path(self):
         self.rc.addMaybe.return_value = None
         msg = self._make_message("/set_maybe_for Bob")
-        with self._rc_started(), self._patch_manager(), self._panel(), \
-             patch('handlers.proxy.add_or_update_proxy_user'):
+        with self._rc_started(), self._patch_manager(), self._panel():
             await self.set_maybe_for(msg)
         self.rc.addMaybe.assert_called_once()
 

--- a/tests/test_parallel_rollcalls.py
+++ b/tests/test_parallel_rollcalls.py
@@ -151,6 +151,9 @@ class TestParallelRollcallsBase(unittest.IsolatedAsyncioTestCase):
             patch('handlers.lists.manager', self.manager),
             patch('handlers.admin.manager', self.manager),
             patch('handlers.settings.manager', self.manager),
+            patch('rollcall_manager.manager', self.manager),
+            patch('services.voting.manager', self.manager),
+            patch('services.proxy.manager', self.manager),
         ])
 
 
@@ -210,10 +213,9 @@ class TestRollcallSelectionByIndex(TestParallelRollcallsBase):
 
         msg = self._make_message("/in ::2")
         with self._rc_started(), patch('handlers.voting.manager', mgr), \
-             patch('handlers.lifecycle._update_panel', return_value=False), \
-             patch('handlers.voting.increment_user_stat'), \
-             patch('handlers.voting.increment_rollcall_stat'), \
-             patch('handlers.voting.get_rc_db_id', return_value=2):
+             patch('rollcall_manager.manager', mgr), \
+             patch('services.voting.manager', mgr), \
+             patch('handlers.lifecycle._update_panel', return_value=False):
             await self.in_user(msg)
 
         mgr.get_rollcall.assert_called_with(100, 1)
@@ -233,10 +235,9 @@ class TestRollcallSelectionByIndex(TestParallelRollcallsBase):
 
         msg = self._make_message("/out ::3")
         with self._rc_started(), patch('handlers.voting.manager', mgr), \
+             patch('rollcall_manager.manager', mgr), \
+             patch('services.voting.manager', mgr), \
              patch('handlers.lifecycle._update_panel', return_value=False), \
-             patch('handlers.voting.increment_user_stat'), \
-             patch('handlers.voting.increment_rollcall_stat'), \
-             patch('handlers.voting.get_rc_db_id', return_value=3), \
              patch('handlers.lifecycle.notify_proxy_owner_wait_to_in', new=AsyncMock()):
             await self.out_user(msg)
 
@@ -352,8 +353,9 @@ class TestProxyUserWithParallel(TestParallelRollcallsBase):
 
         msg = self._make_message("/set_in_for Bob ::2")
         with self._rc_started(), patch('handlers.proxy.manager', mgr), \
-             patch('handlers.lifecycle.show_panel_for_rollcall', new=AsyncMock()), \
-             patch('handlers.proxy.add_or_update_proxy_user'):
+             patch('rollcall_manager.manager', mgr), \
+             patch('services.proxy.manager', mgr), \
+             patch('handlers.lifecycle.show_panel_for_rollcall', new=AsyncMock()):
             await self.set_in_for(msg)
 
         mgr.get_rollcall.assert_called_with(100, 1)


### PR DESCRIPTION
## Summary

- Fixes 26 broken unit tests caused by slices 4a–4c moving business logic into `services/` while tests still patched handler-level symbols that no longer exist there
- Restores a regression (H2) where `upsert_chat_member` was skipped when the ghost-reconf prompt fired early in `in_user`
- Fixes `asyncio.create_task` multi-line patterns in `proxy.py` and `voting.py` that the `TestLogTaskExc` source-scan was flagging as missing `.add_done_callback`

## Details

- `_patch_manager()` in test base classes now also patches `rollcall_manager.manager`, `services.voting.manager`, `services.proxy.manager` so `resolve_rollcall_or_raise` and the write-lock see the test mock
- Removed stale patches for `handlers.voting.{increment_user_stat, increment_rollcall_stat, get_rc_db_id}` and `handlers.proxy.add_or_update_proxy_user` — `db` is globally mocked in conftest so no stub needed
- Ghost-tracking test patches updated: `get_ghost_count` and `get_ghost_count_by_proxy_name` now live in the service modules
- `upsert_chat_member` called eagerly in `in_user` before the ghost-reconf branch

## Test plan

- [x] 298 unit tests pass
- [x] 567 integration tests pass